### PR TITLE
Force prediction step dt to be nonzero

### DIFF
--- a/examples/ex_ekf_vector.py
+++ b/examples/ex_ekf_vector.py
@@ -60,6 +60,8 @@ results_list = []
 for k in range(len(input_data) - 1):
     u = input_data[k]
 
+    x = ekf.predict(x, u)
+    
     # Fuse any measurements that have occurred.
     while y.stamp < input_data[k + 1].stamp and meas_idx < len(meas_data):
 
@@ -74,7 +76,6 @@ for k in range(len(input_data) - 1):
 
 
     #print(u.stamp-x.state.stamp)
-    x = ekf.predict(x, u)
 
     
     results_list.append(GaussianResult(x, gt_data[k]))

--- a/examples/ex_ekf_vector.py
+++ b/examples/ex_ekf_vector.py
@@ -30,7 +30,7 @@ range_freqs = [50, 50, 50]
 process_model = SingleIntegrator(Q)
 input_profile = lambda t: np.array([np.sin(t), np.cos(t)])
 input_covariance = Q
-input_freq = 200
+input_freq = 180
 
 # ##############################################################################
 # Data Generation
@@ -65,12 +65,18 @@ for k in range(len(input_data) - 1):
 
         x = ekf.correct(x, y, u)
 
+        dt = u.stamp-x.state.stamp
+
         # Load the next measurement
         meas_idx += 1
         if meas_idx < len(meas_data):
             y = meas_data[meas_idx]
 
+
+    #print(u.stamp-x.state.stamp)
     x = ekf.predict(x, u)
+
+    
     results_list.append(GaussianResult(x, gt_data[k]))
 
 print("Average filter computation frequency (Hz):")

--- a/examples/ex_iterated_ekf_se2.py
+++ b/examples/ex_iterated_ekf_se2.py
@@ -51,7 +51,8 @@ y = meas_data[meas_idx]
 results_list = []
 for k in range(len(input_data) - 1):
     u = input_data[k]
-
+    x = ekf.predict(x, u)
+    
     # Fuse any measurements that have occurred.
     while y.stamp < input_data[k + 1].stamp and meas_idx < len(meas_data):
 
@@ -60,7 +61,6 @@ for k in range(len(input_data) - 1):
         if meas_idx < len(meas_data):
             y = meas_data[meas_idx]
 
-    x = ekf.predict(x, u)
     results_list.append(GaussianResult(x, state_true[k]))
 
 

--- a/examples/ex_monte_carlo.py
+++ b/examples/ex_monte_carlo.py
@@ -59,7 +59,7 @@ def ekf_trial(trial_number:int) -> List[GaussianResult]:
     results_list = []
     for k in range(len(input_data) - 1):
         u = input_data[k]
-
+        
         # Fuse any measurements that have occurred.
         while y.stamp < input_data[k + 1].stamp and meas_idx < len(meas_data):
 
@@ -75,7 +75,7 @@ def ekf_trial(trial_number:int) -> List[GaussianResult]:
 
 # %% Run the monte carlo experiment
 
-N = 10
+N = 5
 
 results = monte_carlo(ekf_trial, N)
 

--- a/examples/ex_monte_carlo.py
+++ b/examples/ex_monte_carlo.py
@@ -59,6 +59,7 @@ def ekf_trial(trial_number:int) -> List[GaussianResult]:
     results_list = []
     for k in range(len(input_data) - 1):
         u = input_data[k]
+        x = ekf.predict(x, u)
         
         # Fuse any measurements that have occurred.
         while y.stamp < input_data[k + 1].stamp and meas_idx < len(meas_data):
@@ -68,7 +69,7 @@ def ekf_trial(trial_number:int) -> List[GaussianResult]:
             if meas_idx < len(meas_data):
                 y = meas_data[meas_idx]
 
-        x = ekf.predict(x, u)
+        
         results_list.append(GaussianResult(x, state_true[k]))
 
     return results_list

--- a/pynav/filters.py
+++ b/pynav/filters.py
@@ -8,6 +8,12 @@ from .types import (
 )
 import numpy as np
 from scipy.stats.distributions import chi2
+import warnings
+
+def format_warning(message, category, filename, lineno, line=''):
+    # Required to format warning string. 
+    return str(filename) + ':' + str(lineno) + ': ' + category.__name__ + ': ' +str(message) + '\n'
+warnings.formatwarning = format_warning
 
 
 def check_outlier(error: np.ndarray, covariance: np.ndarray):
@@ -93,7 +99,10 @@ class ExtendedKalmanFilter:
 
         if dt is None:
             dt = u.stamp - x.state.stamp
-
+            if np.isclose(u.stamp, x.state.stamp, atol=1e-10):
+                warnings.warn("Timestep dt is zero at time "+ str(u.stamp))
+            if dt < 0:
+                warnings.warn("Timestep dt is negative at time u: "+ str(u.stamp) + "time x: " + str(x.state.stamp))
         # Load dedicated jacobian evaluation point if user specified.
         if x_jac is None:
             x_jac = x.state

--- a/pynav/types.py
+++ b/pynav/types.py
@@ -130,22 +130,80 @@ class ProcessModel(ABC):
     Abstract process model base class for process models of the form 
 
     .. math::
-        \mathbf{x}_k = \mathbf{f}(\mathbf{x}_{k-1}, \mathbf{u}_{k-1}, \Delta t) + \mathbf{w}_{k-1}
+        \mathbf{x}_k = \mathbf{f}(\mathbf{x}_{k-1}, \mathbf{u}, \Delta t) + \mathbf{w}_{k}
 
-    where :math:`\mathbf{u}_{k-1}` is the input and :math:`\Delta t` is the time 
-    period between the two states.
-
+    where :math:`\mathbf{u}` is the input, :math:`\Delta t` is the time 
+    period between the two states, and :math:`\mathbf{w}_{k} \sim \mathcal{N}(\mathbf{0}, \mathbf{Q}_k)`
+    is additive Gaussian noise.
     """
     @abstractmethod
     def evaluate(self, x: State, u: StampedValue, dt: float) -> State:
+        """
+        Implementation of :math:`\mathbf{f}(\mathbf{x}_{k-1}, \mathbf{u}, \Delta t)`.
+
+        Parameters
+        ----------
+        x : State
+            State at time :math:`k-1`.
+        u : StampedValue
+            The input value :math:`\mathbf{u}` provided as a StampedValue object.
+            The actual numerical value is accessed via `u.value`.
+        dt : float
+            The time interval :math:`\Delta t` between the two states.
+
+        Returns
+        -------
+        State
+            State at time :math:`k`.
+        """
         pass
 
     @abstractmethod
     def jacobian(self, x: State, u: StampedValue, dt: float) -> np.ndarray:
+        """
+        Implementation of the process model Jacobian with respect to the state.
+
+        .. math::
+            \mathbf{F} = \partial \mathbf{f}(\mathbf{x}_{k-1}, \mathbf{u}, \Delta t)
+            / \partial \mathbf{x}_{k-1}
+
+
+        Parameters
+        ----------
+        x : State
+            State at time :math:`k-1`.
+        u : StampedValue
+            The input value :math:`\mathbf{u}` provided as a StampedValue object.
+        dt : float
+            The time interval :math:`\Delta t` between the two states.
+
+        Returns
+        -------
+        np.ndarray
+            Process model Jacobian with respect to the state :math:`\mathbf{F}`.
+        """
         pass
 
     @abstractmethod
     def covariance(self, x: State, u: StampedValue, dt: float) -> np.ndarray:
+        """
+        Covariance matrix math:`\mathbf{Q}_k` of the additive Gaussian 
+        noise :math:`\mathbf{w}_{k} \sim \mathcal{N}(\mathbf{0}, \mathbf{Q}_k)`.
+
+        Parameters
+        ----------
+        x : State
+            State at time :math:`k-1`.
+        u : StampedValue
+            The input value :math:`\mathbf{u}` provided as a StampedValue object.
+        dt : float
+            The time interval :math:`\Delta t` between the two states.
+
+        Returns
+        -------
+        np.ndarray
+            Covariance matrix :math:`\mathbf{Q}_k`.
+        """
         pass
 
     def jacobian_fd(self, x: State, u: StampedValue, dt: float) -> np.ndarray:

--- a/pynav/utils.py
+++ b/pynav/utils.py
@@ -144,10 +144,9 @@ def monte_carlo(trial: Callable[[int], List[GaussianResult]], num_trials: int):
     trial_results = [None] * num_trials
     
     print("Starting Monte Carlo experiment...")
-    for i in tqdm(range(num_trials)):
+    for i in tqdm(range(num_trials), unit="trial", ncols=80):
         # Execute the trial
         trial_results[i] = GaussianResultList(trial(i))
-
     return MonteCarloResult(trial_results)
 
 


### PR DESCRIPTION
This line of code 
`        if dt is None:
            dt = u.stamp - x.state.stamp`
becomes problematic for the case where u and x are from same timestep. Which is what happened in previous change when we started passing in u into the predict method. Until now this passed silently which causes bugs that are hard to track down. This PR a) adds an exception when dt=0 and b) Changed the examples to explicitly pass in dt into predict method. 