### PR TITLE
Minor bugfixes with process noise matrix

### DIFF
--- a/pynav/datagen.py
+++ b/pynav/datagen.py
@@ -156,7 +156,7 @@ class DataGenerator:
 
             # Add noise to input if requested.
             if noise:
-                Q = np.atleast_2d(self.input_covariance)
+                Q = np.atleast_2d(Q_func(times[i]))
                 u.plus(randvec(Q))
 
             state_list.append(x.copy())

--- a/pynav/lib/models.py
+++ b/pynav/lib/models.py
@@ -54,7 +54,7 @@ class DoubleIntegrator(ProcessModel):
     def __init__(self, Q: np.ndarray):
         '''
         inputs:
-            Q: Continuous time covariance on the input u. 
+            Q: Discrete time covariance on the input u. 
         '''
         if Q.shape[0] != Q.shape[1]:
             raise ValueError("Q must be an n x n matrix.")
@@ -88,7 +88,7 @@ class DoubleIntegrator(ProcessModel):
         f = 1e-15
         fudge_factor = np.array([[f, 0],
                                 [0, 0]])
-        return  Lc @ self._Q @ Lc.T * dt + fudge_factor
+        return  Lc @ self._Q @ Lc.T * dt**2 + fudge_factor
 
 class OneDimensionalPositionVelocityRange(MeasurementModel):
     '''


### PR DESCRIPTION
Main fix is
        if noise:
            Q = np.atleast_2d(self.input_covariance) (Previous)
            Q = np.atleast_2d(Q_func(times[i])) (New) 
            u.plus(randvec(Q))

And fixed my time-varying noise example.