### PR TITLE
Add Interacting Multiple Model Filter

### DIFF
--- a/examples/ex_interacting_multiple_model_se3.py
+++ b/examples/ex_interacting_multiple_model_se3.py
@@ -23,8 +23,8 @@ from typing import List
 import time
 from matplotlib import pyplot as plt
 from pynav.imm import InteractingModelFilter, run_interacting_multiple_model_filter
-from pynav.imm import ImmResultList
-from pynav.imm import ImmState, gaussian_mixing, ImmResult
+from pynav.imm import IMMResultList
+from pynav.imm import IMMState, gaussian_mixing, IMMResult
 
 """This example runs an Interacting Multiple Model filter to estimate the process model noise matrix
 for a state that is on a Lie group. The performance is compared to an EKF that knows the ground
@@ -92,15 +92,15 @@ class VaryingNoiseProcessModel(process_model_true):
 
 N = 5
 Q_dg = np.eye(x0.value.shape[0])
-N_MODELS = len(imm_process_model_list)
+n_models = len(imm_process_model_list)
 
 # Kalman Filter bank
 kf_list = [ExtendedKalmanFilter(pm) for pm in imm_process_model_list]
 
 # Set up probability transition matrix
 off_diag_p = 0.02
-Pi = np.ones((N_MODELS, N_MODELS)) * off_diag_p
-Pi = Pi + (1 - off_diag_p * (N_MODELS)) * np.diag(np.ones(N_MODELS))
+Pi = np.ones((n_models, n_models)) * off_diag_p
+Pi = Pi + (1 - off_diag_p * (n_models)) * np.diag(np.ones(n_models))
 imm = InteractingModelFilter(kf_list, Pi)
 
 
@@ -129,10 +129,10 @@ def imm_trial(trial_number: int) -> List[GaussianResult]:
     )
 
     results = [
-        ImmResult(estimate_list[i], state_true[i]) for i in range(len(estimate_list))
+        IMMResult(estimate_list[i], state_true[i]) for i in range(len(estimate_list))
     ]
 
-    return ImmResultList(results)
+    return IMMResultList(results)
 
 
 def ekf_trial(trial_number: int) -> List[GaussianResult]:
@@ -213,14 +213,14 @@ if N < 15:
         np.array([t.model_probabilities for t in results.trial_results]), axis=0
     )
     fig, ax = plt.subplots(1, 1)
-    for lv1 in range(N_MODELS):
+    for lv1 in range(n_models):
         ax.plot(results.stamp, average_model_probabilities[lv1, :])
     ax.set_xlabel("Time (s)")
     ax.set_ylabel("Model Probabilities")
 
 fig, ax = plt.subplots(1, 1)
 Q_ = np.zeros(results.stamp.shape)
-for lv1 in range(N_MODELS):
+for lv1 in range(n_models):
     Q_ = Q_ + average_model_probabilities[lv1, :] * c_list[lv1] * Q_ref[0, 0]
 
 ax.plot(results.stamp, Q_, label=r"$Q_{00}$, Estimated")

--- a/examples/ex_interacting_multiple_model_se3.py
+++ b/examples/ex_interacting_multiple_model_se3.py
@@ -1,4 +1,5 @@
-from pynav.filters import ExtendedKalmanFilter
+import pytest
+from pynav.filters import ExtendedKalmanFilter, run_filter
 from pynav.lib.states import VectorState, SO3State, SE3State
 from pynav.datagen import DataGenerator
 from pynav.types import StampedValue, StateWithCovariance
@@ -6,9 +7,13 @@ from pynav.utils import GaussianResult, GaussianResultList, MonteCarloResult
 from pynav.utils import randvec
 
 from pynav.utils import monte_carlo, plot_error
-
+from pynav.lib.models import DoubleIntegrator, OneDimensionalPositionVelocityRange
+from pynav.lib.models import SingleIntegrator, RangePointToAnchor
 from pynav.lib.models import (
     BodyFrameVelocity,
+    InvariantMeasurement,
+    Magnetometer,
+    Gravitometer,
 )
 from pynav.lib.models import RangePoseToAnchor
 from pylie import SO3, SE3
@@ -18,137 +23,167 @@ from typing import List
 import time
 from matplotlib import pyplot as plt
 from pynav.imm import InteractingModelFilter, run_interacting_multiple_model_filter
-from pynav.imm import run_time_varying_Q_filter
 from pynav.imm import ImmResultList
+from pynav.imm import ImmState, gaussian_mixing, ImmResult
 
+"""This example runs an Interacting Multiple Model filter to estimate the process model noise matrix
+for a state that is on a Lie group. The performance is compared to an EKF that knows the ground
+truth process model noise. 
+"""
 
-def make_range_models_iterated_ekf(R):
-    range_models = [
-        RangePoseToAnchor([1, 0, 0], [0.17, 0.17, 0], R),
-        RangePoseToAnchor([1, 0, 0], [-0.17, 0.17, 0], R),
-        RangePoseToAnchor([-1, 0, 0], [0.17, 0.17, 0], R),
-        RangePoseToAnchor([-1, 0, 0], [-0.17, 0.17, 0], R),
-        RangePoseToAnchor([0, 2, 0], [0.17, 0.17, 0], R),
-        RangePoseToAnchor([0, 2, 0], [-0.17, 0.17, 0], R),
-        RangePoseToAnchor([0, 2, 2], [0.17, 0.17, 0], R),
-        RangePoseToAnchor([0, 2, 2], [-0.17, 0.17, 0], R),
-    ]
-    return range_models
-
-def make_filter_trial(dg, x0_true, P0, t_max, imm, process_model, Q_profile):
-        
-    def imm_trial(trial_number: int) -> List[GaussianResult]:
-        """
-        A single Interacting Multiple Model Filter trial
-        """
-        np.random.seed(trial_number)
-        state_true, input_list, meas_list = dg.generate(x0_true, 0, t_max, True)
-
-        x0_check = x0_true.copy()
-        x0_check = x0_check.plus(randvec(P0))
-        estimate_list, model_probabilities = run_interacting_multiple_model_filter(imm, x0_check, P0, input_list, meas_list)
-
-        results = \
-        [
-            GaussianResult(estimate_list[i], state_true[i])
-            for i in range(len(estimate_list))
-        ]
-        
-        return ImmResultList(results, model_probabilities)
-    
-    return imm_trial
-
-
-def make_ekf_trial(dg, x0_true, P0, t_max, ekf, process_model, Q_profile):
-        
-    def ekf_trial(trial_number: int) -> List[GaussianResult]:
-        """
-        A single EKF trial for an EKF which uses a time-varying process noise matrix.
-        """
-        np.random.seed(trial_number)
-        state_true, input_list, meas_list = dg.generate(x0_true, 0, t_max, True)
-
-        x0_check = x0_true.copy()
-        x0_check = x0_check.plus(randvec(P0))
-        estimate_list = run_time_varying_Q_filter(ekf, process_model, Q_profile, x0_check, P0, input_list, meas_list)
-
-        results = GaussianResultList(
-        [
-            GaussianResult(estimate_list[i], state_true[i])
-            for i in range(len(estimate_list))
-        ]
-        )
-        return results
-    
-    return ekf_trial
-
-# The two models correspond to the BodyVelocityModel which uses two different Q matrices. 
-# The two different Q matrices are a Q_ref matrix which is scaled by a scalar, c. 
+# Create the process model noise profile
 c_list = [1, 9]
 Q_ref = np.diag([0.01**2, 0.01**2, 0.01**2, 0.1, 0.1, 0.1])
-def make_nd_Q_profile_varying(t_max, n_inputs):
-    def Q_profile(t):
-        if t <= t_max/4:
-            c = c_list[0]
-        if t > t_max/4 and t <= t_max*3/4:
-            c = c_list[1]
-        if t > t_max*3/4:
-            c = c_list[0]
-        Q = c*Q_ref
-        return Q
-    return Q_profile
 
-x0, P0, input_profile, process_model_true, measurement_model, \
-    make_Q_profile, R, input_freq, measurement_freq, imm_process_model_list = \
-(SE3State(SE3.Exp([0, 0, 0, 0, 0, 0]), stamp=0.0), 0.1**2 * np.identity(6), 
-                        lambda t, x: np.array([np.sin(0.1 * t), np.cos(0.1 * t), np.sin(0.1 * t), 1, 0, 0]),
-                        BodyFrameVelocity, make_range_models_iterated_ekf, 
-                        make_nd_Q_profile_varying, 0.1**2, 
-                        10, 5, 
-                        [BodyFrameVelocity(c_list[0]*Q_ref), BodyFrameVelocity(c_list[1]*Q_ref)]
-                        )
-                        
-dt = 1/input_freq
-t_max = dt*100
-N = 10
+
+def Q_profile(t):
+    if t <= t_max / 4:
+        c = c_list[0]
+    if t > t_max / 4 and t <= t_max * 3 / 4:
+        c = c_list[1]
+    if t > t_max * 3 / 4:
+        c = c_list[0]
+    Q = c * Q_ref
+    return Q
+
+
+# Measurement model
+R = 0.1**2
+range_models = [
+    RangePoseToAnchor([1, 0, 0], [0.17, 0.17, 0], R),
+    RangePoseToAnchor([1, 0, 0], [-0.17, 0.17, 0], R),
+    RangePoseToAnchor([-1, 0, 0], [0.17, 0.17, 0], R),
+    RangePoseToAnchor([-1, 0, 0], [-0.17, 0.17, 0], R),
+    RangePoseToAnchor([0, 2, 0], [0.17, 0.17, 0], R),
+    RangePoseToAnchor([0, 2, 0], [-0.17, 0.17, 0], R),
+    RangePoseToAnchor([0, 2, 2], [0.17, 0.17, 0], R),
+    RangePoseToAnchor([0, 2, 2], [-0.17, 0.17, 0], R),
+]
+
+# Setup
+x0 = SE3State(SE3.Exp([0, 0, 0, 0, 0, 0]), stamp=0.0)
+P0 = 0.1**2 * np.identity(6)
+input_profile = lambda t, x: np.array(
+    [np.sin(0.1 * t), np.cos(0.1 * t), np.sin(0.1 * t), 1, 0, 0]
+)
+process_model_true = BodyFrameVelocity
+input_freq = 10
+dt = 1 / input_freq
+t_max = dt * 100
+measurement_freq = 5
+
+# The two models correspond to the BodyVelocityModel which uses two different Q matrices.
+# The two different Q matrices are a Q_ref matrix which is scaled by a scalar, c.
+imm_process_model_list = [
+    BodyFrameVelocity(c_list[0] * Q_ref),
+    BodyFrameVelocity(c_list[1] * Q_ref),
+]
+
+
+class VaryingNoiseProcessModel(process_model_true):
+    def __init__(self, Q_profile):
+        self.Q_profile = Q_profile
+        super().__init__(Q_profile(0))
+
+    def covariance(self, x, u, dt) -> np.ndarray:
+        self._Q = self.Q_profile(x.stamp)
+        return super().covariance(x, u, dt)
+
+
+N = 5
 Q_dg = np.eye(x0.value.shape[0])
-n_inputs = input_profile(0, np.zeros(x0.value.shape[0])).shape[0]
 N_MODELS = len(imm_process_model_list)
 
-# Kalman filter bank for the IMM
-kf_list = [ExtendedKalmanFilter(pm) for pm in imm_process_model_list] 
+# Kalman Filter bank
+kf_list = [ExtendedKalmanFilter(pm) for pm in imm_process_model_list]
 
-# Set up the probability transition matrix
+# Set up probability transition matrix
 off_diag_p = 0.02
-Pi = np.ones((N_MODELS,N_MODELS))*off_diag_p
-Pi = Pi+(1-off_diag_p*(N_MODELS))*np.diag(np.ones(N_MODELS))
-Q_profile = make_Q_profile(t_max, n_inputs)
+Pi = np.ones((N_MODELS, N_MODELS)) * off_diag_p
+Pi = Pi + (1 - off_diag_p * (N_MODELS)) * np.diag(np.ones(N_MODELS))
+imm = InteractingModelFilter(kf_list, Pi)
+
+
 dg = DataGenerator(
-    process_model_true(Q_dg),
+    VaryingNoiseProcessModel(Q_profile),
     input_profile,
     Q_profile,
     input_freq,
-    measurement_model(R),
+    range_models,
     measurement_freq,
+)
+
+
+def imm_trial(trial_number: int) -> List[GaussianResult]:
+    """
+    A single Interacting Multiple Model Filter trial
+    """
+    np.random.seed(trial_number)
+    state_true, input_list, meas_list = dg.generate(x0, 0, t_max, True)
+
+    x0_check = x0.copy()
+    x0_check = x0_check.plus(randvec(P0))
+
+    estimate_list = run_interacting_multiple_model_filter(
+        imm, x0_check, P0, input_list, meas_list
     )
 
-imm_trial = make_filter_trial(dg, x0, P0, t_max, InteractingModelFilter(kf_list, Pi), process_model_true, Q_profile)
-results = monte_carlo(imm_trial, N)
+    results = [
+        ImmResult(estimate_list[i], state_true[i]) for i in range(len(estimate_list))
+    ]
 
-ekf_trial = make_ekf_trial(dg, x0, P0, t_max, ExtendedKalmanFilter, process_model_true, Q_profile)
+    return ImmResultList(results)
+
+
+def ekf_trial(trial_number: int) -> List[GaussianResult]:
+    """
+    A single trial in a monte carlo experiment. This function accepts the trial
+    number and must return a list of GaussianResult objects.
+    """
+
+    # By using the trial number as the seed for the random generator, we can
+    # make sure our experiments are perfectly repeatable, yet still have
+    # independent noise samples from trial-to-trial.
+    np.random.seed(trial_number)
+
+    state_true, input_list, meas_list = dg.generate(x0, 0, t_max, noise=True)
+    x0_check = x0.plus(randvec(P0))
+    ekf = ExtendedKalmanFilter(VaryingNoiseProcessModel(Q_profile))
+
+    estimate_list = run_filter(ekf, x0, P0, input_list, meas_list)
+    results = [
+        GaussianResult(estimate_list[i], state_true[i])
+        for i in range(len(estimate_list))
+    ]
+
+    return GaussianResultList(results)
+
+
+results = monte_carlo(imm_trial, N)
 results_ekf = monte_carlo(ekf_trial, N)
 
 import matplotlib.pyplot as plt
 import seaborn as sns
 
-sns.set_theme(style='whitegrid')
+sns.set_theme(style="whitegrid")
 
 fig, ax = plt.subplots(1, 1)
-ax.plot(results.stamp, results.average_nees, label = "IMM NEES")
-ax.plot(results.stamp, results_ekf.average_nees, label = "EKF using GT Q NEES")
+ax.plot(results.stamp, results.average_nees, label="IMM NEES")
+ax.plot(results.stamp, results_ekf.average_nees, label="EKF using GT Q NEES")
 ax.plot(results.stamp, results.expected_nees, color="r", label="Expected NEES")
-ax.plot( results.stamp, results.nees_lower_bound(0.99), color="k", linestyle="--", label="99 percent c.i.",)
-ax.plot(results.stamp, results.nees_upper_bound(0.99), color="k", linestyle="--",)
+ax.plot(
+    results.stamp,
+    results.nees_lower_bound(0.99),
+    color="k",
+    linestyle="--",
+    label="99 percent c.i.",
+)
+ax.plot(
+    results.stamp,
+    results.nees_upper_bound(0.99),
+    color="k",
+    linestyle="--",
+)
 ax.set_title("{0}-trial average NEES".format(results.num_trials))
 ax.set_ylim(0, None)
 ax.set_xlabel("Time (s)")
@@ -175,8 +210,8 @@ if N < 15:
     axs[1].set_xlabel("Time (s)")
 
     average_model_probabilities = np.average(
-                np.array([t.model_probabilities for t in results.trial_results]), axis=0
-            )
+        np.array([t.model_probabilities for t in results.trial_results]), axis=0
+    )
     fig, ax = plt.subplots(1, 1)
     for lv1 in range(N_MODELS):
         ax.plot(results.stamp, average_model_probabilities[lv1, :])
@@ -186,12 +221,15 @@ if N < 15:
 fig, ax = plt.subplots(1, 1)
 Q_ = np.zeros(results.stamp.shape)
 for lv1 in range(N_MODELS):
-    Q_ = Q_ + average_model_probabilities[lv1, :]*c_list[lv1]*Q_ref[0,0]
+    Q_ = Q_ + average_model_probabilities[lv1, :] * c_list[lv1] * Q_ref[0, 0]
 
-ax.plot(results.stamp, Q_, label =r'$Q_{00}$, Estimated')
-ax.plot(results.stamp, np.array([Q_profile(t)[0, 0] for t in results.stamp]), label =r'$Q_{00}$, GT')
+ax.plot(results.stamp, Q_, label=r"$Q_{00}$, Estimated")
+ax.plot(
+    results.stamp,
+    np.array([Q_profile(t)[0, 0] for t in results.stamp]),
+    label=r"$Q_{00}$, GT",
+)
 ax.set_xlabel("Time (s)")
-ax.set_ylabel(r'$Q_{00}$')
+ax.set_ylabel(r"$Q_{00}$")
 
 plt.show()
-

--- a/examples/ex_interacting_multiple_model_se3.py
+++ b/examples/ex_interacting_multiple_model_se3.py
@@ -1,0 +1,197 @@
+from pynav.filters import ExtendedKalmanFilter
+from pynav.lib.states import VectorState, SO3State, SE3State
+from pynav.datagen import DataGenerator
+from pynav.types import StampedValue, StateWithCovariance
+from pynav.utils import GaussianResult, GaussianResultList, MonteCarloResult
+from pynav.utils import randvec
+
+from pynav.utils import monte_carlo, plot_error
+
+from pynav.lib.models import (
+    BodyFrameVelocity,
+)
+from pynav.lib.models import RangePoseToAnchor
+from pylie import SO3, SE3
+
+import numpy as np
+from typing import List
+import time
+from matplotlib import pyplot as plt
+from pynav.imm import InteractingModelFilter, run_interacting_multiple_model_filter
+from pynav.imm import run_time_varying_Q_filter
+from pynav.imm import ImmResultList
+
+
+def make_range_models_iterated_ekf(R):
+    range_models = [
+        RangePoseToAnchor([1, 0, 0], [0.17, 0.17, 0], R),
+        RangePoseToAnchor([1, 0, 0], [-0.17, 0.17, 0], R),
+        RangePoseToAnchor([-1, 0, 0], [0.17, 0.17, 0], R),
+        RangePoseToAnchor([-1, 0, 0], [-0.17, 0.17, 0], R),
+        RangePoseToAnchor([0, 2, 0], [0.17, 0.17, 0], R),
+        RangePoseToAnchor([0, 2, 0], [-0.17, 0.17, 0], R),
+        RangePoseToAnchor([0, 2, 2], [0.17, 0.17, 0], R),
+        RangePoseToAnchor([0, 2, 2], [-0.17, 0.17, 0], R),
+    ]
+    return range_models
+
+def make_filter_trial(dg, x0_true, P0, t_max, imm, process_model, Q_profile):
+        
+    def imm_trial(trial_number: int) -> List[GaussianResult]:
+        """
+        A single Interacting Multiple Model Filter trial
+        """
+        np.random.seed(trial_number)
+        state_true, input_list, meas_list = dg.generate(x0_true, 0, t_max, True)
+
+        x0_check = x0_true.copy()
+        x0_check = x0_check.plus(randvec(P0))
+        estimate_list, model_probabilities = run_interacting_multiple_model_filter(imm, x0_check, P0, input_list, meas_list)
+
+        results = \
+        [
+            GaussianResult(estimate_list[i], state_true[i])
+            for i in range(len(estimate_list))
+        ]
+        
+        return ImmResultList(results, model_probabilities)
+    
+    return imm_trial
+
+
+def make_ekf_trial(dg, x0_true, P0, t_max, ekf, process_model, Q_profile):
+        
+    def ekf_trial(trial_number: int) -> List[GaussianResult]:
+        """
+        A single EKF trial for an EKF which uses a time-varying process noise matrix.
+        """
+        np.random.seed(trial_number)
+        state_true, input_list, meas_list = dg.generate(x0_true, 0, t_max, True)
+
+        x0_check = x0_true.copy()
+        x0_check = x0_check.plus(randvec(P0))
+        estimate_list = run_time_varying_Q_filter(ekf, process_model, Q_profile, x0_check, P0, input_list, meas_list)
+
+        results = GaussianResultList(
+        [
+            GaussianResult(estimate_list[i], state_true[i])
+            for i in range(len(estimate_list))
+        ]
+        )
+        return results
+    
+    return ekf_trial
+
+# The two models correspond to the BodyVelocityModel which uses two different Q matrices. 
+# The two different Q matrices are a Q_ref matrix which is scaled by a scalar, c. 
+c_list = [1, 9]
+Q_ref = np.diag([0.01**2, 0.01**2, 0.01**2, 0.1, 0.1, 0.1])
+def make_nd_Q_profile_varying(t_max, n_inputs):
+    def Q_profile(t):
+        if t <= t_max/4:
+            c = c_list[0]
+        if t > t_max/4 and t <= t_max*3/4:
+            c = c_list[1]
+        if t > t_max*3/4:
+            c = c_list[0]
+        Q = c*Q_ref
+        return Q
+    return Q_profile
+
+x0, P0, input_profile, process_model_true, measurement_model, \
+    make_Q_profile, R, input_freq, measurement_freq, imm_process_model_list = \
+(SE3State(SE3.Exp([0, 0, 0, 0, 0, 0]), stamp=0.0), 0.1**2 * np.identity(6), 
+                        lambda t, x: np.array([np.sin(0.1 * t), np.cos(0.1 * t), np.sin(0.1 * t), 1, 0, 0]),
+                        BodyFrameVelocity, make_range_models_iterated_ekf, 
+                        make_nd_Q_profile_varying, 0.1**2, 
+                        10, 5, 
+                        [BodyFrameVelocity(c_list[0]*Q_ref), BodyFrameVelocity(c_list[1]*Q_ref)]
+                        )
+                        
+dt = 1/input_freq
+t_max = dt*100
+N = 10
+Q_dg = np.eye(x0.value.shape[0])
+n_inputs = input_profile(0, np.zeros(x0.value.shape[0])).shape[0]
+N_MODELS = len(imm_process_model_list)
+
+# Kalman filter bank for the IMM
+kf_list = [ExtendedKalmanFilter(pm) for pm in imm_process_model_list] 
+
+# Set up the probability transition matrix
+off_diag_p = 0.02
+Pi = np.ones((N_MODELS,N_MODELS))*off_diag_p
+Pi = Pi+(1-off_diag_p*(N_MODELS))*np.diag(np.ones(N_MODELS))
+Q_profile = make_Q_profile(t_max, n_inputs)
+dg = DataGenerator(
+    process_model_true(Q_dg),
+    input_profile,
+    Q_profile,
+    input_freq,
+    measurement_model(R),
+    measurement_freq,
+    )
+
+imm_trial = make_filter_trial(dg, x0, P0, t_max, InteractingModelFilter(kf_list, Pi), process_model_true, Q_profile)
+results = monte_carlo(imm_trial, N)
+
+ekf_trial = make_ekf_trial(dg, x0, P0, t_max, ExtendedKalmanFilter, process_model_true, Q_profile)
+results_ekf = monte_carlo(ekf_trial, N)
+
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+sns.set_theme(style='whitegrid')
+
+fig, ax = plt.subplots(1, 1)
+ax.plot(results.stamp, results.average_nees, label = "IMM NEES")
+ax.plot(results.stamp, results_ekf.average_nees, label = "EKF using GT Q NEES")
+ax.plot(results.stamp, results.expected_nees, color="r", label="Expected NEES")
+ax.plot( results.stamp, results.nees_lower_bound(0.99), color="k", linestyle="--", label="99 percent c.i.",)
+ax.plot(results.stamp, results.nees_upper_bound(0.99), color="k", linestyle="--",)
+ax.set_title("{0}-trial average NEES".format(results.num_trials))
+ax.set_ylim(0, None)
+ax.set_xlabel("Time (s)")
+ax.set_ylabel("NEES")
+ax.legend()
+
+
+if N < 15:
+
+    fig, axs = plt.subplots(2, 1)
+    axs: List[plt.Axes] = axs
+    for result in results.trial_results:
+        plot_error(result, axs=axs)
+
+    axs[0].set_title("Estimation error IMM")
+    axs[1].set_xlabel("Time (s)")
+
+    fig, axs = plt.subplots(2, 1)
+    axs: List[plt.Axes] = axs
+    for result in results_ekf.trial_results:
+        plot_error(result, axs=axs)
+
+    axs[0].set_title("Estimation error EKF GT")
+    axs[1].set_xlabel("Time (s)")
+
+    average_model_probabilities = np.average(
+                np.array([t.model_probabilities for t in results.trial_results]), axis=0
+            )
+    fig, ax = plt.subplots(1, 1)
+    for lv1 in range(N_MODELS):
+        ax.plot(results.stamp, average_model_probabilities[lv1, :])
+    ax.set_xlabel("Time (s)")
+    ax.set_ylabel("Model Probabilities")
+
+fig, ax = plt.subplots(1, 1)
+Q_ = np.zeros(results.stamp.shape)
+for lv1 in range(N_MODELS):
+    Q_ = Q_ + average_model_probabilities[lv1, :]*c_list[lv1]*Q_ref[0,0]
+
+ax.plot(results.stamp, Q_, label =r'$Q_{00}$, Estimated')
+ax.plot(results.stamp, np.array([Q_profile(t)[0, 0] for t in results.stamp]), label =r'$Q_{00}$, GT')
+ax.set_xlabel("Time (s)")
+ax.set_ylabel(r'$Q_{00}$')
+
+plt.show()
+

--- a/examples/ex_interacting_multiple_model_vector.py
+++ b/examples/ex_interacting_multiple_model_vector.py
@@ -23,7 +23,7 @@ from typing import List
 import time
 from matplotlib import pyplot as plt
 from pynav.imm import InteractingModelFilter, run_interacting_multiple_model_filter
-from pynav.imm import ImmResultList, ImmResult
+from pynav.imm import IMMResultList, IMMResult
 
 
 """This example runs an Interacting Multiple Model filter to estimate the process model noise matrix
@@ -83,15 +83,15 @@ class VaryingNoiseProcessModel(process_model_true):
 N = 5
 Q_dg = np.eye(x0.value.shape[0])
 n_inputs = input_profile(0, np.zeros(x0.value.shape[0])).shape[0]
-N_MODELS = len(imm_process_model_list)
+n_models = len(imm_process_model_list)
 
 # Kalman Filter bank
 kf_list = [ExtendedKalmanFilter(pm) for pm in imm_process_model_list]
 
 # Set up probability transition matrix
 off_diag_p = 0.02
-Pi = np.ones((N_MODELS, N_MODELS)) * off_diag_p
-Pi = Pi + (1 - off_diag_p * (N_MODELS)) * np.diag(np.ones(N_MODELS))
+Pi = np.ones((n_models, n_models)) * off_diag_p
+Pi = Pi + (1 - off_diag_p * (n_models)) * np.diag(np.ones(n_models))
 imm = InteractingModelFilter(kf_list, Pi)
 
 dg = DataGenerator(
@@ -119,10 +119,10 @@ def imm_trial(trial_number: int) -> List[GaussianResult]:
     )
 
     results = [
-        ImmResult(estimate_list[i], state_true[i]) for i in range(len(estimate_list))
+        IMMResult(estimate_list[i], state_true[i]) for i in range(len(estimate_list))
     ]
 
-    return ImmResultList(results)
+    return IMMResultList(results)
 
 
 def ekf_trial(trial_number: int) -> List[GaussianResult]:
@@ -203,14 +203,14 @@ if N < 15:
         np.array([t.model_probabilities for t in results.trial_results]), axis=0
     )
     fig, ax = plt.subplots(1, 1)
-    for lv1 in range(N_MODELS):
+    for lv1 in range(n_models):
         ax.plot(results.stamp, average_model_probabilities[lv1, :])
     ax.set_xlabel("Time (s)")
     ax.set_ylabel("Model Probabilities")
 
 fig, ax = plt.subplots(1, 1)
 Q_ = np.zeros(results.stamp.shape)
-for lv1 in range(N_MODELS):
+for lv1 in range(n_models):
     Q_ = Q_ + average_model_probabilities[lv1, :] * c_list[lv1] * Q_ref[0, 0]
 
 ax.plot(results.stamp, Q_, label=r"$Q_{00}$, Estimated")

--- a/examples/ex_interacting_multiple_model_vector.py
+++ b/examples/ex_interacting_multiple_model_vector.py
@@ -1,5 +1,5 @@
 import pytest
-from pynav.filters import ExtendedKalmanFilter
+from pynav.filters import ExtendedKalmanFilter, run_filter
 from pynav.lib.states import VectorState, SO3State, SE3State
 from pynav.datagen import DataGenerator
 from pynav.types import StampedValue, StateWithCovariance
@@ -22,129 +22,158 @@ import numpy as np
 from typing import List
 import time
 from matplotlib import pyplot as plt
-from pynav.imm import InteractingModelFilter, run_interacting_multiple_model_filter, run_time_varying_Q_filter
-from pynav.imm import ImmResultList
+from pynav.imm import InteractingModelFilter, run_interacting_multiple_model_filter
+from pynav.imm import ImmResultList, ImmResult
 
 
-def make_onedimensional_range(R):
-    range_models=[
-        OneDimensionalPositionVelocityRange(R)
-    ]
-    return range_models
-
-def make_filter_trial(dg, x0_true, P0, t_max, imm, process_model, Q_profile):
-        
-    def imm_trial(trial_number: int) -> List[GaussianResult]:
-        """
-        A single Interacting Multiple Model Filter trial
-        """
-        np.random.seed(trial_number)
-        state_true, input_list, meas_list = dg.generate(x0_true, 0, t_max, True)
-
-        x0_check = x0_true.copy()
-        x0_check = x0_check.plus(randvec(P0))
-        estimate_list, model_probabilities = run_interacting_multiple_model_filter(imm, x0_check, P0, input_list, meas_list)
-
-        results = \
-        [
-            GaussianResult(estimate_list[i], state_true[i])
-            for i in range(len(estimate_list))
-        ]
-        
-        return ImmResultList(results, model_probabilities)
-    
-    return imm_trial
+"""This example runs an Interacting Multiple Model filter to estimate the process model noise matrix
+for a state that is on a vector space. The performance is compared to an EKF that knows the ground
+truth process model noise. 
+"""
 
 
-def make_ekf_trial(dg, x0_true, P0, t_max, ekf, process_model, Q_profile):
-        
-    def ekf_trial(trial_number: int) -> List[GaussianResult]:
-        """
-        A single EKF trial for an EKF which uses a time-varying process noise matrix.
-        """
-        np.random.seed(trial_number)
-        state_true, input_list, meas_list = dg.generate(x0_true, 0, t_max, True)
+# Measurement model
+R = 0.1**4
+range_models = [OneDimensionalPositionVelocityRange(R)]
 
-        x0_check = x0_true.copy()
-        x0_check = x0_check.plus(randvec(P0))
-        estimate_list = run_time_varying_Q_filter(ekf, process_model, Q_profile, x0_check, P0, input_list, meas_list)
-
-        results = GaussianResultList(
-        [
-            GaussianResult(estimate_list[i], state_true[i])
-            for i in range(len(estimate_list))
-        ]
-        )
-        return results
-    
-    return ekf_trial
-
-# The two models correspond to the BodyVelocityModel which uses two different Q matrices. 
-# The two different Q matrices are a Q_ref matrix which is scaled by a scalar, c. 
+# Process model noise setup
 c_list = [1, 9]
 Q_ref = np.eye(1)
-def make_nd_Q_profile_varying(t_max, n_inputs):
-    def Q_profile(t):
-        if t <= t_max/4:
-            c = c_list[0]
-        if t > t_max/4 and t <= t_max*3/4:
-            c = c_list[1]
-        if t > t_max*3/4:
-            c = c_list[0]
-        Q = c*Q_ref
-        return Q
-    return Q_profile
+input_freq = 10
+dt = 1 / input_freq
+t_max = dt * 1000
 
-x0, P0, input_profile, process_model_true, measurement_model, \
-    make_Q_profile, R, input_freq, measurement_freq, imm_process_model_list = \
-                    (VectorState(np.array([1, 0]), 0.0), np.diag([1, 1]), 
-                    lambda t, x: np.array([np.sin(t)]),
-                    DoubleIntegrator, make_onedimensional_range, 
-                    make_nd_Q_profile_varying, 0.1**4, 
-                    10, 5, [DoubleIntegrator(c_list[0]*Q_ref), DoubleIntegrator(c_list[1]*Q_ref)])
-                      
-dt = 1/input_freq
-t_max = dt*1000
-N = 10
+
+def Q_profile(t):
+    if t <= t_max / 4:
+        c = c_list[0]
+    if t > t_max / 4 and t <= t_max * 3 / 4:
+        c = c_list[1]
+    if t > t_max * 3 / 4:
+        c = c_list[0]
+    Q = c * Q_ref
+    return Q
+
+
+# Setup
+x0 = VectorState(np.array([1, 0]), 0.0)
+P0 = np.diag([1, 1])
+input_profile = lambda t, x: np.array([np.sin(t)])
+process_model_true = DoubleIntegrator
+measurement_freq = 5
+
+# The two models correspond to the DoubleIntegrator which uses two different Q matrices.
+# The two different Q matrices are a Q_ref matrix which is scaled by a scalar, c.
+imm_process_model_list = [
+    DoubleIntegrator(c_list[0] * Q_ref),
+    DoubleIntegrator(c_list[1] * Q_ref),
+]
+
+
+class VaryingNoiseProcessModel(process_model_true):
+    def __init__(self, Q_profile):
+        self.Q_profile = Q_profile
+        super().__init__(Q_profile(0))
+
+    def covariance(self, x, u, dt) -> np.ndarray:
+        self._Q = self.Q_profile(x.stamp)
+        return super().covariance(x, u, dt)
+
+
+N = 5
 Q_dg = np.eye(x0.value.shape[0])
 n_inputs = input_profile(0, np.zeros(x0.value.shape[0])).shape[0]
 N_MODELS = len(imm_process_model_list)
 
 # Kalman Filter bank
-kf_list = [ExtendedKalmanFilter(pm) for pm in imm_process_model_list] 
+kf_list = [ExtendedKalmanFilter(pm) for pm in imm_process_model_list]
 
 # Set up probability transition matrix
 off_diag_p = 0.02
-Pi = np.ones((N_MODELS,N_MODELS))*off_diag_p
-Pi = Pi+(1-off_diag_p*(N_MODELS))*np.diag(np.ones(N_MODELS))
+Pi = np.ones((N_MODELS, N_MODELS)) * off_diag_p
+Pi = Pi + (1 - off_diag_p * (N_MODELS)) * np.diag(np.ones(N_MODELS))
+imm = InteractingModelFilter(kf_list, Pi)
 
-Q_profile = make_Q_profile(t_max, n_inputs)
 dg = DataGenerator(
-    process_model_true(Q_dg),
+    VaryingNoiseProcessModel(Q_profile),
     input_profile,
     Q_profile,
     input_freq,
-    measurement_model(R),
+    range_models,
     measurement_freq,
+)
+
+
+def imm_trial(trial_number: int) -> List[GaussianResult]:
+    """
+    A single Interacting Multiple Model Filter trial
+    """
+    np.random.seed(trial_number)
+    state_true, input_list, meas_list = dg.generate(x0, 0, t_max, True)
+
+    x0_check = x0.copy()
+    x0_check = x0_check.plus(randvec(P0))
+
+    estimate_list = run_interacting_multiple_model_filter(
+        imm, x0_check, P0, input_list, meas_list
     )
 
-imm_trial = make_filter_trial(dg, x0, P0, t_max, InteractingModelFilter(kf_list, Pi), process_model_true, Q_profile)
-results = monte_carlo(imm_trial, N)
+    results = [
+        ImmResult(estimate_list[i], state_true[i]) for i in range(len(estimate_list))
+    ]
 
-ekf_trial = make_ekf_trial(dg, x0, P0, t_max, ExtendedKalmanFilter, process_model_true, Q_profile)
+    return ImmResultList(results)
+
+
+def ekf_trial(trial_number: int) -> List[GaussianResult]:
+    """
+    A single trial in a monte carlo experiment. This function accepts the trial
+    number and must return a list of GaussianResult objects.
+    """
+
+    # By using the trial number as the seed for the random generator, we can
+    # make sure our experiments are perfectly repeatable, yet still have
+    # independent noise samples from trial-to-trial.
+    np.random.seed(trial_number)
+
+    state_true, input_list, meas_list = dg.generate(x0, 0, t_max, noise=True)
+    x0_check = x0.plus(randvec(P0))
+    ekf = ExtendedKalmanFilter(VaryingNoiseProcessModel(Q_profile))
+
+    estimate_list = run_filter(ekf, x0, P0, input_list, meas_list)
+    results = [
+        GaussianResult(estimate_list[i], state_true[i])
+        for i in range(len(estimate_list))
+    ]
+
+    return GaussianResultList(results)
+
+
+results = monte_carlo(imm_trial, N)
 results_ekf = monte_carlo(ekf_trial, N)
 
 import matplotlib.pyplot as plt
 import seaborn as sns
 
-sns.set_theme(style='whitegrid')
+sns.set_theme(style="whitegrid")
 
 fig, ax = plt.subplots(1, 1)
-ax.plot(results.stamp, results.average_nees, label = "IMM NEES")
-ax.plot(results.stamp, results_ekf.average_nees, label = "EKF using GT Q NEES")
+ax.plot(results.stamp, results.average_nees, label="IMM NEES")
+ax.plot(results.stamp, results_ekf.average_nees, label="EKF using GT Q NEES")
 ax.plot(results.stamp, results.expected_nees, color="r", label="Expected NEES")
-ax.plot( results.stamp, results.nees_lower_bound(0.99), color="k", linestyle="--", label="99 percent c.i.",)
-ax.plot(results.stamp, results.nees_upper_bound(0.99), color="k", linestyle="--",)
+ax.plot(
+    results.stamp,
+    results.nees_lower_bound(0.99),
+    color="k",
+    linestyle="--",
+    label="99 percent c.i.",
+)
+ax.plot(
+    results.stamp,
+    results.nees_upper_bound(0.99),
+    color="k",
+    linestyle="--",
+)
 ax.set_title("{0}-trial average NEES".format(results.num_trials))
 ax.set_ylim(0, None)
 ax.set_xlabel("Time (s)")
@@ -171,8 +200,8 @@ if N < 15:
     axs[1].set_xlabel("Time (s)")
 
     average_model_probabilities = np.average(
-                np.array([t.model_probabilities for t in results.trial_results]), axis=0
-            )
+        np.array([t.model_probabilities for t in results.trial_results]), axis=0
+    )
     fig, ax = plt.subplots(1, 1)
     for lv1 in range(N_MODELS):
         ax.plot(results.stamp, average_model_probabilities[lv1, :])
@@ -182,12 +211,15 @@ if N < 15:
 fig, ax = plt.subplots(1, 1)
 Q_ = np.zeros(results.stamp.shape)
 for lv1 in range(N_MODELS):
-    Q_ = Q_ + average_model_probabilities[lv1, :]*c_list[lv1]*Q_ref[0,0]
+    Q_ = Q_ + average_model_probabilities[lv1, :] * c_list[lv1] * Q_ref[0, 0]
 
-ax.plot(results.stamp, Q_, label =r'$Q_{00}$, Estimated')
-ax.plot(results.stamp, np.array([Q_profile(t)[0, 0] for t in results.stamp]), label =r'$Q_{00}$, GT')
+ax.plot(results.stamp, Q_, label=r"$Q_{00}$, Estimated")
+ax.plot(
+    results.stamp,
+    np.array([Q_profile(t)[0, 0] for t in results.stamp]),
+    label=r"$Q_{00}$, GT",
+)
 ax.set_xlabel("Time (s)")
-ax.set_ylabel(r'$Q_{00}$')
+ax.set_ylabel(r"$Q_{00}$")
 
 plt.show()
-

--- a/examples/ex_interacting_multiple_model_vector.py
+++ b/examples/ex_interacting_multiple_model_vector.py
@@ -1,0 +1,193 @@
+import pytest
+from pynav.filters import ExtendedKalmanFilter
+from pynav.lib.states import VectorState, SO3State, SE3State
+from pynav.datagen import DataGenerator
+from pynav.types import StampedValue, StateWithCovariance
+from pynav.utils import GaussianResult, GaussianResultList, MonteCarloResult
+from pynav.utils import randvec
+
+from pynav.utils import monte_carlo, plot_error
+from pynav.lib.models import DoubleIntegrator, OneDimensionalPositionVelocityRange
+from pynav.lib.models import SingleIntegrator, RangePointToAnchor
+from pynav.lib.models import (
+    BodyFrameVelocity,
+    InvariantMeasurement,
+    Magnetometer,
+    Gravitometer,
+)
+from pynav.lib.models import RangePoseToAnchor
+from pylie import SO3, SE3
+
+import numpy as np
+from typing import List
+import time
+from matplotlib import pyplot as plt
+from pynav.imm import InteractingModelFilter, run_interacting_multiple_model_filter, run_time_varying_Q_filter
+from pynav.imm import ImmResultList
+
+
+def make_onedimensional_range(R):
+    range_models=[
+        OneDimensionalPositionVelocityRange(R)
+    ]
+    return range_models
+
+def make_filter_trial(dg, x0_true, P0, t_max, imm, process_model, Q_profile):
+        
+    def imm_trial(trial_number: int) -> List[GaussianResult]:
+        """
+        A single Interacting Multiple Model Filter trial
+        """
+        np.random.seed(trial_number)
+        state_true, input_list, meas_list = dg.generate(x0_true, 0, t_max, True)
+
+        x0_check = x0_true.copy()
+        x0_check = x0_check.plus(randvec(P0))
+        estimate_list, model_probabilities = run_interacting_multiple_model_filter(imm, x0_check, P0, input_list, meas_list)
+
+        results = \
+        [
+            GaussianResult(estimate_list[i], state_true[i])
+            for i in range(len(estimate_list))
+        ]
+        
+        return ImmResultList(results, model_probabilities)
+    
+    return imm_trial
+
+
+def make_ekf_trial(dg, x0_true, P0, t_max, ekf, process_model, Q_profile):
+        
+    def ekf_trial(trial_number: int) -> List[GaussianResult]:
+        """
+        A single EKF trial for an EKF which uses a time-varying process noise matrix.
+        """
+        np.random.seed(trial_number)
+        state_true, input_list, meas_list = dg.generate(x0_true, 0, t_max, True)
+
+        x0_check = x0_true.copy()
+        x0_check = x0_check.plus(randvec(P0))
+        estimate_list = run_time_varying_Q_filter(ekf, process_model, Q_profile, x0_check, P0, input_list, meas_list)
+
+        results = GaussianResultList(
+        [
+            GaussianResult(estimate_list[i], state_true[i])
+            for i in range(len(estimate_list))
+        ]
+        )
+        return results
+    
+    return ekf_trial
+
+# The two models correspond to the BodyVelocityModel which uses two different Q matrices. 
+# The two different Q matrices are a Q_ref matrix which is scaled by a scalar, c. 
+c_list = [1, 9]
+Q_ref = np.eye(1)
+def make_nd_Q_profile_varying(t_max, n_inputs):
+    def Q_profile(t):
+        if t <= t_max/4:
+            c = c_list[0]
+        if t > t_max/4 and t <= t_max*3/4:
+            c = c_list[1]
+        if t > t_max*3/4:
+            c = c_list[0]
+        Q = c*Q_ref
+        return Q
+    return Q_profile
+
+x0, P0, input_profile, process_model_true, measurement_model, \
+    make_Q_profile, R, input_freq, measurement_freq, imm_process_model_list = \
+                    (VectorState(np.array([1, 0]), 0.0), np.diag([1, 1]), 
+                    lambda t, x: np.array([np.sin(t)]),
+                    DoubleIntegrator, make_onedimensional_range, 
+                    make_nd_Q_profile_varying, 0.1**4, 
+                    10, 5, [DoubleIntegrator(c_list[0]*Q_ref), DoubleIntegrator(c_list[1]*Q_ref)])
+                      
+dt = 1/input_freq
+t_max = dt*1000
+N = 10
+Q_dg = np.eye(x0.value.shape[0])
+n_inputs = input_profile(0, np.zeros(x0.value.shape[0])).shape[0]
+N_MODELS = len(imm_process_model_list)
+
+# Kalman Filter bank
+kf_list = [ExtendedKalmanFilter(pm) for pm in imm_process_model_list] 
+
+# Set up probability transition matrix
+off_diag_p = 0.02
+Pi = np.ones((N_MODELS,N_MODELS))*off_diag_p
+Pi = Pi+(1-off_diag_p*(N_MODELS))*np.diag(np.ones(N_MODELS))
+
+Q_profile = make_Q_profile(t_max, n_inputs)
+dg = DataGenerator(
+    process_model_true(Q_dg),
+    input_profile,
+    Q_profile,
+    input_freq,
+    measurement_model(R),
+    measurement_freq,
+    )
+
+imm_trial = make_filter_trial(dg, x0, P0, t_max, InteractingModelFilter(kf_list, Pi), process_model_true, Q_profile)
+results = monte_carlo(imm_trial, N)
+
+ekf_trial = make_ekf_trial(dg, x0, P0, t_max, ExtendedKalmanFilter, process_model_true, Q_profile)
+results_ekf = monte_carlo(ekf_trial, N)
+
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+sns.set_theme(style='whitegrid')
+
+fig, ax = plt.subplots(1, 1)
+ax.plot(results.stamp, results.average_nees, label = "IMM NEES")
+ax.plot(results.stamp, results_ekf.average_nees, label = "EKF using GT Q NEES")
+ax.plot(results.stamp, results.expected_nees, color="r", label="Expected NEES")
+ax.plot( results.stamp, results.nees_lower_bound(0.99), color="k", linestyle="--", label="99 percent c.i.",)
+ax.plot(results.stamp, results.nees_upper_bound(0.99), color="k", linestyle="--",)
+ax.set_title("{0}-trial average NEES".format(results.num_trials))
+ax.set_ylim(0, None)
+ax.set_xlabel("Time (s)")
+ax.set_ylabel("NEES")
+ax.legend()
+
+
+if N < 15:
+
+    fig, axs = plt.subplots(2, 1)
+    axs: List[plt.Axes] = axs
+    for result in results.trial_results:
+        plot_error(result, axs=axs)
+
+    axs[0].set_title("Estimation error IMM")
+    axs[1].set_xlabel("Time (s)")
+
+    fig, axs = plt.subplots(2, 1)
+    axs: List[plt.Axes] = axs
+    for result in results_ekf.trial_results:
+        plot_error(result, axs=axs)
+
+    axs[0].set_title("Estimation error EKF GT")
+    axs[1].set_xlabel("Time (s)")
+
+    average_model_probabilities = np.average(
+                np.array([t.model_probabilities for t in results.trial_results]), axis=0
+            )
+    fig, ax = plt.subplots(1, 1)
+    for lv1 in range(N_MODELS):
+        ax.plot(results.stamp, average_model_probabilities[lv1, :])
+    ax.set_xlabel("Time (s)")
+    ax.set_ylabel("Model Probabilities")
+
+fig, ax = plt.subplots(1, 1)
+Q_ = np.zeros(results.stamp.shape)
+for lv1 in range(N_MODELS):
+    Q_ = Q_ + average_model_probabilities[lv1, :]*c_list[lv1]*Q_ref[0,0]
+
+ax.plot(results.stamp, Q_, label =r'$Q_{00}$, Estimated')
+ax.plot(results.stamp, np.array([Q_profile(t)[0, 0] for t in results.stamp]), label =r'$Q_{00}$, GT')
+ax.set_xlabel("Time (s)")
+ax.set_ylabel(r'$Q_{00}$')
+
+plt.show()
+

--- a/pynav/imm.py
+++ b/pynav/imm.py
@@ -1,6 +1,6 @@
-
-
+from logging import Filter
 from typing import List
+
 from .types import (
     StampedValue,
     State,
@@ -16,236 +16,276 @@ from pynav.filters import ExtendedKalmanFilter, check_outlier
 from pynav.utils import GaussianResultList, GaussianResult
 
 
-class ImmResultList(GaussianResultList):
+def gaussian_mixing_vectorspace(
+    weights: List[float], x_list: List[StateWithCovariance]
+):
+    """Calculate the mean and covariance of a Gaussian mixture on a vectorspace.
+
+    Parameters
+    ----------
+    weights : List[Float]
+        Weights corresponding to each Gaussian.
+    x_list : List[StateWithCovariance]
+        Gaussians to be mixed, with each element of x_list containing the mean
+        and covariance of the corresponding Gaussian. Each state must
+        be a VectorState.
+
+    Returns
+    -------
+    StateWithCovariance
+        A single StateWithCovariance containing the mean and covariance of the mixed Gaussian.
+    """
+    x_bar = StateWithCovariance(
+        VectorState(np.zeros(x_list[0].state.value.shape), stamp=x_list[0].state.stamp),
+        np.zeros(x_list[0].covariance.shape),
+    ).copy()
+
+    for (weight, x) in zip(weights, x_list):
+        x_bar.state.value = x_bar.state.value + weight * x.state.value
+
+    for (weight, x) in zip(weights, x_list):
+        dx = (x.state.value - x_bar.state.value).reshape(-1, 1)
+        x_bar.covariance = x_bar.covariance + weight * x.covariance + weight * dx @ dx.T
+
+    return x_bar
+
+
+def reparametrize_gaussians_about_X_par(
+    X_par: StateWithCovariance, X_list: List[StateWithCovariance]
+):
+    """Reparametrize each Lie group Gaussian in X_list about X_par.
+    A Lie group Gaussian is only relevant in the tangent space of its own mean.
+    To mix Lie group Gaussians, a specific X, X_par, must be chosen to expand
+    a tangent space around. Once expanded in this common tangent space,
+    the Gaussians may be mixed in a vector space fashion.
+
+    Parameters
+    ----------
+    X_par : StateWithCovariance
+        Each member of X_list will be reparametrized as a Gaussian
+            in the tangent space of X_par.
+    X_list : List[StateWithCovariance]
+        List of Lie group Gaussians to be reparametrized.
+
+    Returns
+    -------
+    List[StateWithCovariance]
+        Where each state is a VectorState. These correspond to the mean and covariance
+        of X_list, expressed in the tangent space of X_par.
+    """
+    x_reparametrized = []
+
+    for X in X_list:
+        mu = X_par.minus(X.state)
+        J = X_par.jacobian(mu)
+        Sigma = J @ X.covariance @ J.T
+        mu = VectorState(mu, stamp=X_par.stamp)
+        x_reparametrized.append(StateWithCovariance(mu, Sigma))
+
+    return x_reparametrized
+
+
+def update_X(X: State, x_hat: StateWithCovariance):
+    """Given a Lie group Gaussian x_hat, expressed in the tangent space of X,
+    compute Lie group StateAndCovariance X_hat such that the Lie algebra Gaussian
+    around X_hat has zero mean.
+
+    Parameters
+    ----------
+    X : State
+        A Lie group element.
+    x_hat : StateWithCovariance
+        StateWithCovariance whose state is a VectorState.
+
+    Returns
+    -------
+    StateWithCovariance
+        StateWithCovariance whose state is a Lie group element.
+    """
+    X_hat = StateWithCovariance(X, np.zeros((X.dof, X.dof)))
+    X_hat.state = X_hat.state.plus(x_hat.state.value)
+    g = X.group
+
+    if X.direction == "right":
+        J = g.right_jacobian(x_hat.state.value)
+        X_hat.covariance = J @ x_hat.covariance @ J.T
+
+    return X_hat
+
+
+def gaussian_mixing(weights: List[float], x_list: List[StateWithCovariance]):
+    """A Gaussian mixing method that handles both vectorspace Gaussians
+        and Gaussians on Lie groups.
+
+    Parameters
+    ----------
+    weights : List[Float]
+        Weights of Gaussians to be mixed.
+    x_list : _List[StateWithCovariance]
+        List of Gaussians to be mixed.
+    Returns
+    -------
+    StateWithCovariance
+        The mixed Gaussian
+    """
+    if isinstance(x_list[0].state, VectorState):
+        X_mix = gaussian_mixing_vectorspace(weights, x_list)
+    if not isinstance(x_list[0].state, VectorState):
+        max_idx = np.argmax(np.array(weights))
+        X_par = x_list[max_idx].state
+        x_repar = reparametrize_gaussians_about_X_par(X_par, x_list)
+        x_hat = gaussian_mixing_vectorspace(weights, x_repar)
+        X_mix = update_X(X_par, x_hat)
+    return X_mix
+
+
+class ImmState:
+    __slots__ = ["model_states", "model_probabilities"]
+
+    def __init__(
+        self, model_states: List[StateWithCovariance], model_probabilities: List[float]
+    ):
+        self.model_states = model_states
+        self.model_probabilities = model_probabilities
+
+
+class ImmResult(GaussianResult):
     __slots__ = [
-    "stamp",
-    "state",
-    "state_true",
-    "covariance",
-    "error",
-    "ees",
-    "nees",
-    "md",
-    "three_sigma",
-    "value",
-    "value_true",
-    "dof",
-    "model_probabilities"
+        "stamp",
+        "state",
+        "state_true",
+        "covariance",
+        "error",
+        "ees",
+        "nees",
+        "md",
+        "three_sigma",
+        "model_probabilities",
     ]
 
-    def __init__(self, result_list: List[GaussianResult], model_probabilities: List):
+    def __init__(self, imm_estimate, state_true):
+        super().__init__(
+            gaussian_mixing(
+                imm_estimate.model_probabilities, imm_estimate.model_states
+            ),
+            state_true,
+        )
+        self.model_probabilities = imm_estimate.model_probabilities
+
+
+class ImmResultList(GaussianResultList):
+    __slots__ = [
+        "stamp",
+        "state",
+        "state_true",
+        "covariance",
+        "error",
+        "ees",
+        "nees",
+        "md",
+        "three_sigma",
+        "value",
+        "value_true",
+        "dof",
+        "model_probabilities",
+    ]
+
+    def __init__(self, result_list: List[ImmResult]):
         super().__init__(result_list)
         self.model_probabilities = []
-        # Turn list of "probability at time step" into 
+        # Turn list of "probability at time step" into
         # list of "probability of model"
-        for lv1 in range(model_probabilities[0].shape[0]):
+        N_MODELS = result_list[0].model_probabilities.shape[0]
+        for lv1 in range(N_MODELS):
             self.model_probabilities.append(
-                np.array([mu[lv1] for mu in model_probabilities])
+                np.array([r.model_probabilities[lv1] for r in result_list])
             )
 
-class InteractingModelFilter():
-    """On-manifold Interacting Multiple Model Filter (IMM). 
-       References for the IMM:
-        @article{blom1988interacting,
-            author = {Blom, Henk A P and Bar-Shalom, Yaakov},
-            journal = {IEEE transactions on Automatic Control},
-            number = {8},
-            pages = {780--783},
-            publisher = {IEEE},
-            title = {{The interacting multiple model algorithm for systems with Markovian switching coefficients}},
-            volume = {33},
-            year = {1988}
-            }
-        The IMM involves Gaussian mixtures. 
-        Reference for mixing Gaussians on manifolds: 
-        @article{7968489,
-            author = {{\'{C}}esi{\'{c}}, Josip and Markovi{\'{c}}, Ivan and Petrovi{\'{c}}, Ivan},
-            doi = {10.1109/LSP.2017.2723765},
-            journal = {IEEE Signal Processing Letters},
-            number = {11},
-            pages = {1719--1723},
-            title = {{Mixture Reduction on Matrix Lie Groups}},
-            volume = {24},
-            year = {2017}
-            }
-        TODOS: Implement methods for left perturbations. 
+
+# TODO: Update docs
+class InteractingModelFilter:
+    """On-manifold Interacting Multiple Model Filter (IMM).
+    References for the IMM:
+     @article{blom1988interacting,
+         author = {Blom, Henk A P and Bar-Shalom, Yaakov},
+         journal = {IEEE transactions on Automatic Control},
+         number = {8},
+         pages = {780--783},
+         publisher = {IEEE},
+         title = {{The interacting multiple model algorithm for systems with Markovian switching coefficients}},
+         volume = {33},
+         year = {1988}
+         }
+     The IMM involves Gaussian mixtures.
+     Reference for mixing Gaussians on manifolds:
+     @article{7968489,
+         author = {{\'{C}}esi{\'{c}}, Josip and Markovi{\'{c}}, Ivan and Petrovi{\'{c}}, Ivan},
+         doi = {10.1109/LSP.2017.2723765},
+         journal = {IEEE Signal Processing Letters},
+         number = {11},
+         pages = {1719--1723},
+         title = {{Mixture Reduction on Matrix Lie Groups}},
+         volume = {24},
+         year = {2017}
+         }
+     TODOS: Implement methods for left perturbations.
 
     """
-    def __init__(self, 
-            kf_list:List[StateWithCovariance], 
-            Pi:np.ndarray):
+
+    def __init__(self, kf_list: List[Filter], Pi: np.ndarray):
         """Initialize InteractingModelFilter.
 
         Parameters
         ----------
         kf_list : List[ExtendedKalmanFilter]
-            A list of filter instances which correspond to 
+            A list of filter instances which correspond to
             each model of the IMM.
         Pi : np.ndarray
             Probability transition matrix corresponding to the IMM models.
         """
         self.kf_list = kf_list
         self.Pi = Pi
-    
-    @staticmethod
-    def gaussian_mixing_vectorspace(weights: List[float], x_list: List[StateWithCovariance]):
-        """Calculate the mean and covariance of a Gaussian mixture on a vectorspace.
+
+    def interaction(
+        self,
+        x: ImmState,
+    ):
+        """The interaction (mixing) step of the IMM.
 
         Parameters
         ----------
-        weights : List[Float]
-            Weights corresponding to each Gaussian.
-        x_list : List[StateWithCovariance]
-            Gaussians to be mixed, with each element of x_list containing the mean
-            and covariance of the corresponding Gaussian. Each state must
-            be a VectorState.
+        x : ImmState
 
         Returns
         -------
-        StateWithCovariance
-            A single StateWithCovariance containing the mean and covariance of the mixed Gaussian. 
-        """
-        x_bar = StateWithCovariance(
-                VectorState(np.zeros(x_list[0].state.value.shape), stamp=x_list[0].state.stamp),
-                np.zeros(x_list[0].covariance.shape)).copy()
-  
-        for (weight, x) in zip(weights, x_list):
-            x_bar.state.value = x_bar.state.value + weight*x.state.value 
-
-        for (weight, x) in zip(weights, x_list):
-            dx = (x.state.value-x_bar.state.value).reshape(-1,1)
-            x_bar.covariance = x_bar.covariance + weight*x.covariance + weight*dx @ dx.T
-
-        return x_bar
-
-    @staticmethod 
-    def reparametrize_gaussians_about_X_par(X_par: StateWithCovariance, X_list: List[StateWithCovariance]):
-        """Reparametrize each Lie group Gaussian in X_list about X_par. 
-        A Lie group Gaussian is only relevant in the tangent space of its own mean. 
-        To mix Lie group Gaussians, a specific X, X_par, must be chosen to expand 
-        a tangent space around. Once expanded in this common tangent space, 
-        the Gaussians may be mixed in a vector space fashion. 
-
-        Parameters
-        ----------
-        X_par : StateWithCovariance
-            Each member of X_list will be reparametrized as a Gaussian
-                in the tangent space of X_par. 
-        X_list : List[StateWithCovariance]
-            List of Lie group Gaussians to be reparametrized. 
-
-        Returns
-        -------
-        List[StateWithCovariance]
-            Where each state is a VectorState. These correspond to the mean and covariance
-            of X_list, expressed in the tangent space of X_par. 
-        """
-        x_reparametrized = []
-        g = X_par.group
-        if X_par.direction == "right":
-            for X in X_list: 
-                mu = g.Log(g.inverse(X_par.value) @ X.state.value)
-                Jr_inv = g.right_jacobian(mu)
-                Sigma = Jr_inv @ X.covariance @ Jr_inv.T 
-                mu = VectorState(mu, stamp = X_par.stamp)
-                x_reparametrized.append(StateWithCovariance(mu, Sigma))
-
-        return x_reparametrized
-
-    @staticmethod  
-    def update_X(X: State, x_hat: StateWithCovariance):
-        """Given a Lie group Gaussian x_hat, expressed in the tangent space of X, 
-        compute Lie group StateAndCovariance X_hat such that the Lie algebra Gaussian
-        around X_hat has zero mean. 
-
-        Parameters
-        ----------
-        X : State
-            A Lie group element. 
-        x_hat : StateWithCovariance
-            StateWithCovariance whose state is a VectorState. 
-
-        Returns
-        -------
-        StateWithCovariance
-            StateWithCovariance whose state is a Lie group element. 
-        """
-        X_hat = StateWithCovariance(X, np.zeros((X.dof, X.dof)))
-        X_hat.state = X_hat.state.plus(x_hat.state.value)
-        g = X.group
-
-        if X.direction == "right":
-            J = g.right_jacobian(x_hat.state.value)
-            X_hat.covariance = J @ x_hat.covariance @ J.T 
-
-        return X_hat
-
-    def gaussian_mixing(self, weights: List[float], x_list: List[StateWithCovariance]):
-        """A Gaussian mixing method that handles both vectorspace Gaussians 
-            and Gaussians on Lie groups. 
-
-        Parameters
-        ----------
-        weights : List[Float]
-            Weights of Gaussians to be mixed.
-        x_list : _List[StateWithCovariance]
-            List of Gaussians to be mixed.
-        Returns
-        -------
-        StateWithCovariance
-            The mixed Gaussian
-        """
-        if isinstance(x_list[0].state, VectorState):
-            X_mix = self.gaussian_mixing_vectorspace(weights, x_list)
-        if not isinstance(x_list[0].state, VectorState):
-            max_idx = np.argmax(np.array(weights))
-            X_par = x_list[max_idx].state
-            x_repar = self.reparametrize_gaussians_about_X_par(X_par, x_list)
-            x_hat = self.gaussian_mixing_vectorspace(weights, x_repar)
-            X_mix = self.update_X(X_par, x_hat)
-        return X_mix
-
-    def interaction (self, mu_models: List[float], x_km_models: List[StateWithCovariance]):
-        """The interaction (mixing) step of the IMM. 
-
-        Parameters
-        ----------
-        mu_models : List[Float]
-            List of probabilities corresponding to each model from previous timestep.
-        x_km_models : List[StateWithCovariance]
-            List of estimates corresponding to each model's estimate from the previous timestep.
-
-        Returns
-        -------
-        List[StateWithCovariance]
-            List of estimates taking into account model mixing of the IMM. 
+        ImmState
         """
 
-        x_km_models = x_km_models.copy() 
-        mu_models = mu_models.copy()
+        x_km_models = x.model_states.copy()
+        mu_models = x.model_probabilities.copy()
 
         N_MODES = self.Pi.shape[0]
-        c = self.Pi.T @ mu_models.reshape(-1,1)
+        c = self.Pi.T @ mu_models.reshape(-1, 1)
 
         mu_mix = np.zeros((N_MODES, N_MODES))
         for i in range(N_MODES):
             for j in range(N_MODES):
-                mu_mix[i, j] = 1./c[j]*self.Pi[i, j]*mu_models[i]
+                mu_mix[i, j] = 1.0 / c[j] * self.Pi[i, j] * mu_models[i]
         x_mix = []
 
         for j in range(N_MODES):
-            weights = list(mu_mix[:,j])
-            x_mix.append(self.gaussian_mixing(weights, x_km_models))
+            weights = list(mu_mix[:, j])
+            x_mix.append(gaussian_mixing(weights, x_km_models))
 
-        return x_mix
+        return ImmState(x_mix, mu_models)
 
-    def predict(self, x_km_models: List[StateWithCovariance], u : StampedValue, dt: float):
-        """Carries out prediction step for each model of the IMM. 
+    def predict(self, x_km: ImmState, u: StampedValue, dt: float):
+        """Carries out prediction step for each model of the IMM.
 
         Parameters
         ----------
-        x_km_models : List[StateWithCovariance]
-            List of model estimates from previous timestep, after mixing. 
+        x_km : ImmState
+            Model estimates from previous timestep, after mixing.
         u : StampedValue
             Input
         dt : Float
@@ -253,43 +293,41 @@ class InteractingModelFilter():
 
         Returns
         -------
-        List[StateWithCovariance]
-            List of model estimates after prediction step is carried out. 
+        ImmState
         """
-        x_km_models = x_km_models.copy() 
+        x_km_models = x_km.model_states.copy()
         x_check = []
         for lv1, kf in enumerate(self.kf_list):
             x_check.append(kf.predict(x_km_models[lv1], u, dt))
-        return x_check
+        return ImmState(x_check, x_km.model_probabilities)
 
-    def correct(self, x_models_check: List[StateWithCovariance], 
-                        mu_km_models: List[float], 
-                        y: Measurement, 
-                        u: StampedValue):
-        """Carry out the correction step for each model and update model probabilities. 
+    def correct(
+        self,
+        x_check: ImmState,
+        y: Measurement,
+        u: StampedValue,
+    ):
+        """Carry out the correction step for each model and update model probabilities.
 
         Parameters
         ----------
-        x_models_check : List[StateWithCovariance]
-            Estimates from each model before correction.
+        x_check: ImmState
         mu_km_models : List[Float]
             Probabilities for each model from previous timestep.
         y : Measurement
             Measurement to be fused into the current state estimate.
         u: StampedValue
-            Most recent input, to be used to predict the state forward 
+            Most recent input, to be used to predict the state forward
             if the measurement stamp is larger than the state stamp.
 
 
         Returns
         -------
-        List[StateWithCovariance]
-            The corrected state estimates for each model
-        List[Float]
-            Updated model probabilities.
+        ImmState
+            Corrected state estimates and probabilities
         """
-        x_models_check = x_models_check.copy() 
-        mu_km_models = mu_km_models.copy()
+        x_models_check = x_check.model_states.copy()
+        mu_km_models = x_check.model_probabilities.copy()
         N_MODES = len(x_models_check)
         mu_k = np.zeros(N_MODES)
 
@@ -297,104 +335,26 @@ class InteractingModelFilter():
         c_bar = np.zeros(N_MODES)
         for i in range(N_MODES):
             for j in range(N_MODES):
-                c_bar[j] = c_bar[j]+self.Pi[i, j]*mu_km_models[i]
+                c_bar[j] = c_bar[j] + self.Pi[i, j] * mu_km_models[i]
 
         # Correct and update model probabilities
         x_hat = []
         for lv1, kf in enumerate(self.kf_list):
-            x, details_dict = \
-                kf.correct(x_models_check[lv1], y, u, output_details = True)
+            x, details_dict = kf.correct(x_models_check[lv1], y, u, output_details=True)
             x_hat.append(x)
             z = details_dict["z"]
             S = details_dict["S"]
             model_likelihood = multivariate_normal.pdf(z, mean=np.zeros(z.shape), cov=S)
-            mu_k[lv1] = model_likelihood*c_bar[lv1]
-        
+            mu_k[lv1] = model_likelihood * c_bar[lv1]
+
         # If all model likelihoods are zero to machine tolerance, np.sum(mu_k)=0 and it fails
         # Add this fudge factor to get through those cases.
         if np.allclose(mu_k, np.zeros(mu_k.shape)):
             mu_k = 1e-10 * np.ones(mu_k.shape)
 
-        mu_k = mu_k/np.sum(mu_k)  
+        mu_k = mu_k / np.sum(mu_k)
 
-        return x_hat, mu_k
-
-
-def run_time_varying_Q_filter(
-    filter,
-    ProcessModel, 
-    Q_profile, 
-    x0: State,
-    P0: np.ndarray,
-    input_data: List[StampedValue],
-    meas_data: List[Measurement],
-) -> List[StateWithCovariance]:
-    """
-    Executes a predict-correct-style filter given lists of input and measurement
-    data. The process model varies with time and this filter must be set to the varied Q 
-    at each time step. 
-
-    Parameters
-    ----------
-    filter : Callable, must return filter with predict and correct methods. 
-        _description_
-    ProcessModel: Callable, must return a process model:
-        _description_
-    Q_profile: Callable, must return a square np.array compatible with process model:
-        _description_
-    x0 : State
-        _description_
-    P0 : np.ndarray
-        _description_
-    input_data : List[StampedValue]
-        _description_
-    meas_data : List[Measurement]
-        _description_
-    """
-    x = StateWithCovariance(x0, P0)
-    if x.state.stamp is None: 
-        raise ValueError("x0 must have a valid timestamp.")
-
-    # Sort the data by time
-    input_data.sort(key = lambda x: x.stamp)
-    meas_data.sort(key = lambda x: x.stamp)
-
-    # Remove all that are before the current time
-    for idx, u in enumerate(input_data):
-        if u.stamp >= x.state.stamp:
-            input_data = input_data[idx:]
-            break
-
-    for idx, y in enumerate(meas_data):
-        if y.stamp >= x.state.stamp:
-            meas_data = meas_data[idx:]
-            break
-
-
-    meas_idx = 0 
-    if len(meas_data) > 0:
-        y = meas_data[meas_idx]
-
-    results_list = []
-    for k in range(len(input_data) - 1):
-        results_list.append(x)
-
-        u = input_data[k]
-        kf = filter(ProcessModel(Q_profile(u.stamp)))
-        # Fuse any measurements that have occurred.
-        if len(meas_data) > 0:
-            while y.stamp < input_data[k + 1].stamp and meas_idx < len(meas_data):
-
-                x = kf.correct(x, y, u)
-                meas_idx += 1
-                if meas_idx < len(meas_data):
-                    y = meas_data[meas_idx]
-
-        dt = input_data[k + 1].stamp - x.stamp
-        x = kf.predict(x, u, dt)
-        
-    return results_list
-
+        return ImmState(x_hat, mu_k)
 
 
 def run_interacting_multiple_model_filter(
@@ -425,12 +385,12 @@ def run_interacting_multiple_model_filter(
         _description_
     """
     x = StateWithCovariance(x0, P0)
-    if x.state.stamp is None: 
+    if x.state.stamp is None:
         raise ValueError("x0 must have a valid timestamp.")
 
     # Sort the data by time
-    input_data.sort(key = lambda x: x.stamp)
-    meas_data.sort(key = lambda x: x.stamp)
+    input_data.sort(key=lambda x: x.stamp)
+    meas_data.sort(key=lambda x: x.stamp)
 
     # Remove all that are before the current time
     for idx, u in enumerate(input_data):
@@ -443,32 +403,30 @@ def run_interacting_multiple_model_filter(
             meas_data = meas_data[idx:]
             break
 
-
-    meas_idx = 0 
+    meas_idx = 0
     if len(meas_data) > 0:
         y = meas_data[meas_idx]
 
     results_list = []
-    model_probabilities = []
     N_MODELS = filter.Pi.shape[0]
-    mu_models = 1./N_MODELS*np.array(np.ones(N_MODELS)) 
-    x_models = [StateWithCovariance(x0, P0)]*N_MODELS
+
+    x = ImmState(
+        [StateWithCovariance(x0, P0)] * N_MODELS,
+        1.0 / N_MODELS * np.array(np.ones(N_MODELS)),
+    )
     for k in range(len(input_data) - 1):
         results_list.append(x)
-        model_probabilities.append(mu_models)
         u = input_data[k]
         # Fuse any measurements that have occurred.
         if len(meas_data) > 0:
             while y.stamp < input_data[k + 1].stamp and meas_idx < len(meas_data):
 
-                x_models = filter.interaction(mu_models, x_models)
-                x_models, mu_models = filter.correct(x_models, mu_models, y, u)
-
+                x = filter.interaction(x)
+                x = filter.correct(x, y, u)
                 meas_idx += 1
                 if meas_idx < len(meas_data):
                     y = meas_data[meas_idx]
-        dt = input_data[k + 1].stamp - x.stamp
-        x_models = filter.predict(x_models, u, dt)
-        x = filter.gaussian_mixing(mu_models, x_models)
-        
-    return results_list, model_probabilities
+        dt = input_data[k + 1].stamp - x.model_states[0].stamp
+        x = filter.predict(x, u, dt)
+
+    return results_list

--- a/pynav/imm.py
+++ b/pynav/imm.py
@@ -104,11 +104,9 @@ def update_X(X: State, x_hat: StateWithCovariance):
     """
     X_hat = StateWithCovariance(X, np.zeros((X.dof, X.dof)))
     X_hat.state = X_hat.state.plus(x_hat.state.value)
-    g = X.group
 
-    if X.direction == "right":
-        J = g.right_jacobian(x_hat.state.value)
-        X_hat.covariance = J @ x_hat.covariance @ J.T
+    J = X.jacobian(x_hat.state.value)
+    X_hat.covariance = J @ x_hat.covariance @ J.T
 
     return X_hat
 

--- a/pynav/imm.py
+++ b/pynav/imm.py
@@ -1,0 +1,474 @@
+
+
+from typing import List
+from .types import (
+    StampedValue,
+    State,
+    ProcessModel,
+    Measurement,
+    StateWithCovariance,
+)
+import numpy as np
+from scipy.stats.distributions import chi2
+from scipy.stats import multivariate_normal
+from pynav.lib.states import VectorState
+from pynav.filters import ExtendedKalmanFilter, check_outlier
+from pynav.utils import GaussianResultList, GaussianResult
+
+
+class ImmResultList(GaussianResultList):
+    __slots__ = [
+    "stamp",
+    "state",
+    "state_true",
+    "covariance",
+    "error",
+    "ees",
+    "nees",
+    "md",
+    "three_sigma",
+    "value",
+    "value_true",
+    "dof",
+    "model_probabilities"
+    ]
+
+    def __init__(self, result_list: List[GaussianResult], model_probabilities: List):
+        super().__init__(result_list)
+        self.model_probabilities = []
+        # Turn list of "probability at time step" into 
+        # list of "probability of model"
+        for lv1 in range(model_probabilities[0].shape[0]):
+            self.model_probabilities.append(
+                np.array([mu[lv1] for mu in model_probabilities])
+            )
+
+class InteractingModelFilter():
+    """On-manifold Interacting Multiple Model Filter (IMM). 
+       References for the IMM:
+        @article{blom1988interacting,
+            author = {Blom, Henk A P and Bar-Shalom, Yaakov},
+            journal = {IEEE transactions on Automatic Control},
+            number = {8},
+            pages = {780--783},
+            publisher = {IEEE},
+            title = {{The interacting multiple model algorithm for systems with Markovian switching coefficients}},
+            volume = {33},
+            year = {1988}
+            }
+        The IMM involves Gaussian mixtures. 
+        Reference for mixing Gaussians on manifolds: 
+        @article{7968489,
+            author = {{\'{C}}esi{\'{c}}, Josip and Markovi{\'{c}}, Ivan and Petrovi{\'{c}}, Ivan},
+            doi = {10.1109/LSP.2017.2723765},
+            journal = {IEEE Signal Processing Letters},
+            number = {11},
+            pages = {1719--1723},
+            title = {{Mixture Reduction on Matrix Lie Groups}},
+            volume = {24},
+            year = {2017}
+            }
+        TODOS: Implement methods for left perturbations. 
+
+    """
+    def __init__(self, 
+            kf_list:List[StateWithCovariance], 
+            Pi:np.ndarray):
+        """Initialize InteractingModelFilter.
+
+        Parameters
+        ----------
+        kf_list : List[ExtendedKalmanFilter]
+            A list of filter instances which correspond to 
+            each model of the IMM.
+        Pi : np.ndarray
+            Probability transition matrix corresponding to the IMM models.
+        """
+        self.kf_list = kf_list
+        self.Pi = Pi
+    
+    @staticmethod
+    def gaussian_mixing_vectorspace(weights: List[float], x_list: List[StateWithCovariance]):
+        """Calculate the mean and covariance of a Gaussian mixture on a vectorspace.
+
+        Parameters
+        ----------
+        weights : List[Float]
+            Weights corresponding to each Gaussian.
+        x_list : List[StateWithCovariance]
+            Gaussians to be mixed, with each element of x_list containing the mean
+            and covariance of the corresponding Gaussian. Each state must
+            be a VectorState.
+
+        Returns
+        -------
+        StateWithCovariance
+            A single StateWithCovariance containing the mean and covariance of the mixed Gaussian. 
+        """
+        x_bar = StateWithCovariance(
+                VectorState(np.zeros(x_list[0].state.value.shape), stamp=x_list[0].state.stamp),
+                np.zeros(x_list[0].covariance.shape)).copy()
+  
+        for (weight, x) in zip(weights, x_list):
+            x_bar.state.value = x_bar.state.value + weight*x.state.value 
+
+        for (weight, x) in zip(weights, x_list):
+            dx = (x.state.value-x_bar.state.value).reshape(-1,1)
+            x_bar.covariance = x_bar.covariance + weight*x.covariance + weight*dx @ dx.T
+
+        return x_bar
+
+    @staticmethod 
+    def reparametrize_gaussians_about_X_par(X_par: StateWithCovariance, X_list: List[StateWithCovariance]):
+        """Reparametrize each Lie group Gaussian in X_list about X_par. 
+        A Lie group Gaussian is only relevant in the tangent space of its own mean. 
+        To mix Lie group Gaussians, a specific X, X_par, must be chosen to expand 
+        a tangent space around. Once expanded in this common tangent space, 
+        the Gaussians may be mixed in a vector space fashion. 
+
+        Parameters
+        ----------
+        X_par : StateWithCovariance
+            Each member of X_list will be reparametrized as a Gaussian
+                in the tangent space of X_par. 
+        X_list : List[StateWithCovariance]
+            List of Lie group Gaussians to be reparametrized. 
+
+        Returns
+        -------
+        List[StateWithCovariance]
+            Where each state is a VectorState. These correspond to the mean and covariance
+            of X_list, expressed in the tangent space of X_par. 
+        """
+        x_reparametrized = []
+        g = X_par.group
+        if X_par.direction == "right":
+            for X in X_list: 
+                mu = g.Log(g.inverse(X_par.value) @ X.state.value)
+                Jr_inv = g.right_jacobian(mu)
+                Sigma = Jr_inv @ X.covariance @ Jr_inv.T 
+                mu = VectorState(mu, stamp = X_par.stamp)
+                x_reparametrized.append(StateWithCovariance(mu, Sigma))
+
+        return x_reparametrized
+
+    @staticmethod  
+    def update_X(X: State, x_hat: StateWithCovariance):
+        """Given a Lie group Gaussian x_hat, expressed in the tangent space of X, 
+        compute Lie group StateAndCovariance X_hat such that the Lie algebra Gaussian
+        around X_hat has zero mean. 
+
+        Parameters
+        ----------
+        X : State
+            A Lie group element. 
+        x_hat : StateWithCovariance
+            StateWithCovariance whose state is a VectorState. 
+
+        Returns
+        -------
+        StateWithCovariance
+            StateWithCovariance whose state is a Lie group element. 
+        """
+        X_hat = StateWithCovariance(X, np.zeros((X.dof, X.dof)))
+        X_hat.state = X_hat.state.plus(x_hat.state.value)
+        g = X.group
+
+        if X.direction == "right":
+            J = g.right_jacobian(x_hat.state.value)
+            X_hat.covariance = J @ x_hat.covariance @ J.T 
+
+        return X_hat
+
+    def gaussian_mixing(self, weights: List[float], x_list: List[StateWithCovariance]):
+        """A Gaussian mixing method that handles both vectorspace Gaussians 
+            and Gaussians on Lie groups. 
+
+        Parameters
+        ----------
+        weights : List[Float]
+            Weights of Gaussians to be mixed.
+        x_list : _List[StateWithCovariance]
+            List of Gaussians to be mixed.
+        Returns
+        -------
+        StateWithCovariance
+            The mixed Gaussian
+        """
+        if isinstance(x_list[0].state, VectorState):
+            X_mix = self.gaussian_mixing_vectorspace(weights, x_list)
+        if not isinstance(x_list[0].state, VectorState):
+            max_idx = np.argmax(np.array(weights))
+            X_par = x_list[max_idx].state
+            x_repar = self.reparametrize_gaussians_about_X_par(X_par, x_list)
+            x_hat = self.gaussian_mixing_vectorspace(weights, x_repar)
+            X_mix = self.update_X(X_par, x_hat)
+        return X_mix
+
+    def interaction (self, mu_models: List[float], x_km_models: List[StateWithCovariance]):
+        """The interaction (mixing) step of the IMM. 
+
+        Parameters
+        ----------
+        mu_models : List[Float]
+            List of probabilities corresponding to each model from previous timestep.
+        x_km_models : List[StateWithCovariance]
+            List of estimates corresponding to each model's estimate from the previous timestep.
+
+        Returns
+        -------
+        List[StateWithCovariance]
+            List of estimates taking into account model mixing of the IMM. 
+        """
+
+        x_km_models = x_km_models.copy() 
+        mu_models = mu_models.copy()
+
+        N_MODES = self.Pi.shape[0]
+        c = self.Pi.T @ mu_models.reshape(-1,1)
+
+        mu_mix = np.zeros((N_MODES, N_MODES))
+        for i in range(N_MODES):
+            for j in range(N_MODES):
+                mu_mix[i, j] = 1./c[j]*self.Pi[i, j]*mu_models[i]
+        x_mix = []
+
+        for j in range(N_MODES):
+            weights = list(mu_mix[:,j])
+            x_mix.append(self.gaussian_mixing(weights, x_km_models))
+
+        return x_mix
+
+    def predict(self, x_km_models: List[StateWithCovariance], u : StampedValue, dt: float):
+        """Carries out prediction step for each model of the IMM. 
+
+        Parameters
+        ----------
+        x_km_models : List[StateWithCovariance]
+            List of model estimates from previous timestep, after mixing. 
+        u : StampedValue
+            Input
+        dt : Float
+            Timestep
+
+        Returns
+        -------
+        List[StateWithCovariance]
+            List of model estimates after prediction step is carried out. 
+        """
+        x_km_models = x_km_models.copy() 
+        x_check = []
+        for lv1, kf in enumerate(self.kf_list):
+            x_check.append(kf.predict(x_km_models[lv1], u, dt))
+        return x_check
+
+    def correct(self, x_models_check: List[StateWithCovariance], 
+                        mu_km_models: List[float], 
+                        y: Measurement, 
+                        u: StampedValue):
+        """Carry out the correction step for each model and update model probabilities. 
+
+        Parameters
+        ----------
+        x_models_check : List[StateWithCovariance]
+            Estimates from each model before correction.
+        mu_km_models : List[Float]
+            Probabilities for each model from previous timestep.
+        y : Measurement
+            Measurement to be fused into the current state estimate.
+        u: StampedValue
+            Most recent input, to be used to predict the state forward 
+            if the measurement stamp is larger than the state stamp.
+
+
+        Returns
+        -------
+        List[StateWithCovariance]
+            The corrected state estimates for each model
+        List[Float]
+            Updated model probabilities.
+        """
+        x_models_check = x_models_check.copy() 
+        mu_km_models = mu_km_models.copy()
+        N_MODES = len(x_models_check)
+        mu_k = np.zeros(N_MODES)
+
+        # Compute each model's normalization constant
+        c_bar = np.zeros(N_MODES)
+        for i in range(N_MODES):
+            for j in range(N_MODES):
+                c_bar[j] = c_bar[j]+self.Pi[i, j]*mu_km_models[i]
+
+        # Correct and update model probabilities
+        x_hat = []
+        for lv1, kf in enumerate(self.kf_list):
+            x, details_dict = \
+                kf.correct(x_models_check[lv1], y, u, output_details = True)
+            x_hat.append(x)
+            z = details_dict["z"]
+            S = details_dict["S"]
+            model_likelihood = multivariate_normal.pdf(z, mean=np.zeros(z.shape), cov=S)
+            mu_k[lv1] = model_likelihood*c_bar[lv1]
+        
+        # If all model likelihoods are zero to machine tolerance, np.sum(mu_k)=0 and it fails
+        # Add this fudge factor to get through those cases.
+        if np.allclose(mu_k, np.zeros(mu_k.shape)):
+            mu_k = 1e-10 * np.ones(mu_k.shape)
+
+        mu_k = mu_k/np.sum(mu_k)  
+
+        return x_hat, mu_k
+
+
+def run_time_varying_Q_filter(
+    filter,
+    ProcessModel, 
+    Q_profile, 
+    x0: State,
+    P0: np.ndarray,
+    input_data: List[StampedValue],
+    meas_data: List[Measurement],
+) -> List[StateWithCovariance]:
+    """
+    Executes a predict-correct-style filter given lists of input and measurement
+    data. The process model varies with time and this filter must be set to the varied Q 
+    at each time step. 
+
+    Parameters
+    ----------
+    filter : Callable, must return filter with predict and correct methods. 
+        _description_
+    ProcessModel: Callable, must return a process model:
+        _description_
+    Q_profile: Callable, must return a square np.array compatible with process model:
+        _description_
+    x0 : State
+        _description_
+    P0 : np.ndarray
+        _description_
+    input_data : List[StampedValue]
+        _description_
+    meas_data : List[Measurement]
+        _description_
+    """
+    x = StateWithCovariance(x0, P0)
+    if x.state.stamp is None: 
+        raise ValueError("x0 must have a valid timestamp.")
+
+    # Sort the data by time
+    input_data.sort(key = lambda x: x.stamp)
+    meas_data.sort(key = lambda x: x.stamp)
+
+    # Remove all that are before the current time
+    for idx, u in enumerate(input_data):
+        if u.stamp >= x.state.stamp:
+            input_data = input_data[idx:]
+            break
+
+    for idx, y in enumerate(meas_data):
+        if y.stamp >= x.state.stamp:
+            meas_data = meas_data[idx:]
+            break
+
+
+    meas_idx = 0 
+    if len(meas_data) > 0:
+        y = meas_data[meas_idx]
+
+    results_list = []
+    for k in range(len(input_data) - 1):
+        results_list.append(x)
+
+        u = input_data[k]
+        kf = filter(ProcessModel(Q_profile(u.stamp)))
+        # Fuse any measurements that have occurred.
+        if len(meas_data) > 0:
+            while y.stamp < input_data[k + 1].stamp and meas_idx < len(meas_data):
+
+                x = kf.correct(x, y, u)
+                meas_idx += 1
+                if meas_idx < len(meas_data):
+                    y = meas_data[meas_idx]
+
+        dt = input_data[k + 1].stamp - x.stamp
+        x = kf.predict(x, u, dt)
+        
+    return results_list
+
+
+
+def run_interacting_multiple_model_filter(
+    filter,
+    x0: State,
+    P0: np.ndarray,
+    input_data: List[StampedValue],
+    meas_data: List[Measurement],
+) -> List[StateWithCovariance]:
+    """
+    Executes an InteractingMultipleModel filter
+
+    Parameters
+    ----------
+    filter: An InteractingModelFilter instance:
+        _description_
+    ProcessModel: Callable, must return a process model:
+        _description_
+    Q_profile: Callable, must return a square np.array compatible with process model:
+        _description_
+    x0 : State
+        _description_
+    P0 : np.ndarray
+        _description_
+    input_data : List[StampedValue]
+        _description_
+    meas_data : List[Measurement]
+        _description_
+    """
+    x = StateWithCovariance(x0, P0)
+    if x.state.stamp is None: 
+        raise ValueError("x0 must have a valid timestamp.")
+
+    # Sort the data by time
+    input_data.sort(key = lambda x: x.stamp)
+    meas_data.sort(key = lambda x: x.stamp)
+
+    # Remove all that are before the current time
+    for idx, u in enumerate(input_data):
+        if u.stamp >= x.state.stamp:
+            input_data = input_data[idx:]
+            break
+
+    for idx, y in enumerate(meas_data):
+        if y.stamp >= x.state.stamp:
+            meas_data = meas_data[idx:]
+            break
+
+
+    meas_idx = 0 
+    if len(meas_data) > 0:
+        y = meas_data[meas_idx]
+
+    results_list = []
+    model_probabilities = []
+    N_MODELS = filter.Pi.shape[0]
+    mu_models = 1./N_MODELS*np.array(np.ones(N_MODELS)) 
+    x_models = [StateWithCovariance(x0, P0)]*N_MODELS
+    for k in range(len(input_data) - 1):
+        results_list.append(x)
+        model_probabilities.append(mu_models)
+        u = input_data[k]
+        # Fuse any measurements that have occurred.
+        if len(meas_data) > 0:
+            while y.stamp < input_data[k + 1].stamp and meas_idx < len(meas_data):
+
+                x_models = filter.interaction(mu_models, x_models)
+                x_models, mu_models = filter.correct(x_models, mu_models, y, u)
+
+                meas_idx += 1
+                if meas_idx < len(meas_data):
+                    y = meas_data[meas_idx]
+        dt = input_data[k + 1].stamp - x.stamp
+        x_models = filter.predict(x_models, u, dt)
+        x = filter.gaussian_mixing(mu_models, x_models)
+        
+    return results_list, model_probabilities

--- a/tests/integration/test_interacting_multiple_models.py
+++ b/tests/integration/test_interacting_multiple_models.py
@@ -24,15 +24,16 @@ import time
 from matplotlib import pyplot as plt
 from pynav.imm import InteractingModelFilter, run_interacting_multiple_model_filter
 from pynav.imm import ImmResultList
+from pynav.imm import ImmState, gaussian_mixing, ImmResult
+
 
 PLOT_FLAG = False
 
 
 def make_onedimensional_range(R):
-    range_models=[
-        OneDimensionalPositionVelocityRange(R)
-    ]
+    range_models = [OneDimensionalPositionVelocityRange(R)]
     return range_models
+
 
 def make_range_models_ekf_vector(R):
     range_models = [
@@ -42,10 +43,12 @@ def make_range_models_ekf_vector(R):
     ]
     return range_models
 
+
 def make_invariant_so3_models(R):
     mag_model = Magnetometer(R)
     grav_model = Gravitometer(R)
     return [mag_model, grav_model]
+
 
 def make_range_models_iterated_ekf(R):
     range_models = [
@@ -60,103 +63,158 @@ def make_range_models_iterated_ekf(R):
     ]
     return range_models
 
+
 def make_filter_trial(dg, x0_true, P0, t_max, imm, process_model, Q_profile):
-        
     def imm_trial(trial_number: int) -> List[GaussianResult]:
         """
-        A single trial in a monte carlo experiment. This function accepts the trial
-        number and must return a list of GaussianResult objects.
+        A single Interacting Multiple Model Filter trial
         """
-
-        # By using the trial number as the seed for the random generator, we can
-        # make sure our experiments are perfectly repeatable, yet still have
-        # independent noise samples from trial-to-trial.
         np.random.seed(trial_number)
         state_true, input_list, meas_list = dg.generate(x0_true, 0, t_max, True)
 
         x0_check = x0_true.copy()
         x0_check = x0_check.plus(randvec(P0))
-        estimate_list, model_probabilities = run_interacting_multiple_model_filter(imm, x0_check, P0, input_list, meas_list)
 
-        results = \
-        [
-            GaussianResult(estimate_list[i], state_true[i])
+        estimate_list = run_interacting_multiple_model_filter(
+            imm, x0_check, P0, input_list, meas_list
+        )
+
+        results = [
+            ImmResult(estimate_list[i], state_true[i])
             for i in range(len(estimate_list))
         ]
-        
-        return ImmResultList(results, model_probabilities)
-    
+
+        return ImmResultList(results)
+
     return imm_trial
 
-# TODO: Generalize. Need to plot model probabilities vs true model. 
-# Need to take a step up from noise matrices to the models. 
 
 def make_c_profile_varying(t_max):
     def c_profile(t):
-        if t <= t_max/4:
+        if t <= t_max / 4:
             c = 1
-        if t > t_max/4 and t <= t_max*3/4:
+        if t > t_max / 4 and t <= t_max * 3 / 4:
             c = 9
-        if t > t_max*3/4:
+        if t > t_max * 3 / 4:
             c = 1
         return c
+
     return c_profile
+
 
 def make_c_profile_const(t_max):
     def c_profile(t):
-        return 1.
+        return 1.0
+
     return c_profile
 
 
-@pytest.mark.parametrize("x0, P0, input_profile, process_model_true, measurement_model, \
-                        make_c_profile, R, input_freq, measurement_freq, imm_process_model_list, Q_ref", 
+@pytest.mark.parametrize(
+    "x0, P0, input_profile, process_model_true, measurement_model, \
+                        make_c_profile, R, input_freq, measurement_freq, imm_process_model_list, Q_ref",
+    [
+        (
+            VectorState(np.array([1, 0]), 0.0),
+            np.diag([1, 1]),
+            lambda t, x: np.array([np.sin(t), np.cos(t)]),
+            SingleIntegrator,
+            make_range_models_ekf_vector,
+            make_c_profile_varying,
+            0.1**2,
+            10,
+            [1, 1, 1],
+            [SingleIntegrator(1 * np.eye(2)), SingleIntegrator(9 * np.eye(2))],
+            np.eye(2),
+        ),
+        (
+            VectorState(np.array([1, 0]), 0.0),
+            np.diag([1, 1]),
+            lambda t, x: np.array([np.sin(t)]),
+            DoubleIntegrator,
+            make_onedimensional_range,
+            make_c_profile_varying,
+            0.1**4,
+            10,
+            5,
+            [DoubleIntegrator(np.eye(1)), DoubleIntegrator(9 * np.eye(1))],
+            np.eye(1),
+        ),
+        (
+            SE3State(SE3.Exp([0, 0, 0, 0, 0, 0]), stamp=0.0),
+            0.1**2 * np.identity(6),
+            lambda t, x: np.array(
+                [np.sin(0.1 * t), np.cos(0.1 * t), np.sin(0.1 * t), 1, 0, 0]
+            ),
+            BodyFrameVelocity,
+            make_range_models_iterated_ekf,
+            make_c_profile_varying,
+            0.1**2,
+            10,
+            5,
             [
-                    (VectorState(np.array([1, 0]), 0.0), np.diag([1, 1]), 
-                    lambda t, x: np.array([np.sin(t), np.cos(t)]),
-                    SingleIntegrator, make_range_models_ekf_vector, 
-                    make_c_profile_varying, 0.1**2, 
-                    10, [1, 1, 1], [SingleIntegrator(1*np.eye(2)), SingleIntegrator(9*np.eye(2))], 
-                    np.eye(2)), 
-                    (VectorState(np.array([1, 0]), 0.0), np.diag([1, 1]), 
-                    lambda t, x: np.array([np.sin(t)]),
-                    DoubleIntegrator, make_onedimensional_range, 
-                    make_c_profile_varying, 0.1**4, 
-                    10, 5, [DoubleIntegrator(np.eye(1)), DoubleIntegrator(9*np.eye(1))], 
-                    np.eye(1)),
-                    (SE3State(SE3.Exp([0, 0, 0, 0, 0, 0]), stamp=0.0), 0.1**2 * np.identity(6), 
-                        lambda t, x: np.array([np.sin(0.1 * t), np.cos(0.1 * t), np.sin(0.1 * t), 1, 0, 0]),
-                        BodyFrameVelocity, make_range_models_iterated_ekf, 
-                        make_c_profile_varying, 0.1**2, 
-                        10, 5, 
-                        [BodyFrameVelocity(np.diag([0.01**2, 0.01**2, 0.01**2, 0.1, 0.1, 0.1])), 
-                        BodyFrameVelocity(9*np.diag([0.01**2, 0.01**2, 0.01**2, 0.1, 0.1, 0.1]))],
-                        np.diag([0.01**2, 0.01**2, 0.01**2, 0.1, 0.1, 0.1])
-                        ), 
-                 ])
-
-def test_reasonable_nees_imm(x0, P0, input_profile, process_model_true, measurement_model, 
-                make_c_profile, R, input_freq, measurement_freq, imm_process_model_list, Q_ref):
-    dt = 1/input_freq
-    t_max = dt*100
+                BodyFrameVelocity(
+                    np.diag([0.01**2, 0.01**2, 0.01**2, 0.1, 0.1, 0.1])
+                ),
+                BodyFrameVelocity(
+                    9 * np.diag([0.01**2, 0.01**2, 0.01**2, 0.1, 0.1, 0.1])
+                ),
+            ],
+            np.diag([0.01**2, 0.01**2, 0.01**2, 0.1, 0.1, 0.1]),
+        ),
+    ],
+)
+def test_reasonable_nees_imm(
+    x0,
+    P0,
+    input_profile,
+    process_model_true,
+    measurement_model,
+    make_c_profile,
+    R,
+    input_freq,
+    measurement_freq,
+    imm_process_model_list,
+    Q_ref,
+):
+    dt = 1 / input_freq
+    t_max = dt * 100
     N = 10
     Q_dg = np.eye(x0.value.shape[0])
     N_MODELS = len(imm_process_model_list)
-    kf_list = [ExtendedKalmanFilter(pm) for pm in imm_process_model_list] 
+    kf_list = [ExtendedKalmanFilter(pm) for pm in imm_process_model_list]
     off_diag_p = 0.02
-    Pi = np.ones((N_MODELS,N_MODELS))*off_diag_p
-    Pi = Pi+(1-off_diag_p*(N_MODELS))*np.diag(np.ones(N_MODELS))
+    Pi = np.ones((N_MODELS, N_MODELS)) * off_diag_p
+    Pi = Pi + (1 - off_diag_p * (N_MODELS)) * np.diag(np.ones(N_MODELS))
     c_profile = make_c_profile(t_max)
-    Q_profile = lambda t: c_profile(t)*Q_ref
+    Q_profile = lambda t: c_profile(t) * Q_ref
+
+    class VaryingNoiseProcessModel(process_model_true):
+        def __init__(self, Q_profile):
+            self.Q_profile = Q_profile
+            super().__init__(Q_profile(0))
+
+        def covariance(self, x, u, dt) -> np.ndarray:
+            self._Q = self.Q_profile(x.stamp)
+            return super().covariance(x, u, dt)
+
     dg = DataGenerator(
-        process_model_true(Q_dg),
+        VaryingNoiseProcessModel(Q_profile),
         input_profile,
         Q_profile,
         input_freq,
         measurement_model(R),
         measurement_freq,
-        )
+    )
 
-    imm_trial = make_filter_trial(dg, x0, P0, t_max, InteractingModelFilter(kf_list, Pi), process_model_true, Q_profile)
+    imm_trial = make_filter_trial(
+        dg,
+        x0,
+        P0,
+        t_max,
+        InteractingModelFilter(kf_list, Pi),
+        process_model_true,
+        Q_profile,
+    )
     results = monte_carlo(imm_trial, N)
 
     if PLOT_FLAG:
@@ -168,14 +226,24 @@ def test_reasonable_nees_imm(x0, P0, input_profile, process_model_true, measurem
         fig, ax = plt.subplots(1, 1)
         ax.plot(results.stamp, results.average_nees)
         ax.plot(results.stamp, results.expected_nees, color="r", label="Expected NEES")
-        ax.plot( results.stamp, results.nees_lower_bound(0.99), color="k", linestyle="--", label="99 percent c.i.",)
-        ax.plot(results.stamp, results.nees_upper_bound(0.99), color="k", linestyle="--",)
+        ax.plot(
+            results.stamp,
+            results.nees_lower_bound(0.99),
+            color="k",
+            linestyle="--",
+            label="99 percent c.i.",
+        )
+        ax.plot(
+            results.stamp,
+            results.nees_upper_bound(0.99),
+            color="k",
+            linestyle="--",
+        )
         ax.set_title("{0}-trial average NEES".format(results.num_trials))
         ax.set_ylim(0, None)
         ax.set_xlabel("Time (s)")
         ax.set_ylabel("NEES")
         ax.legend()
-
 
         if N < 15:
 
@@ -188,8 +256,8 @@ def test_reasonable_nees_imm(x0, P0, input_profile, process_model_true, measurem
             axs[1].set_xlabel("Time (s)")
 
         average_model_probabilities = np.average(
-                    np.array([t.model_probabilities for t in results.trial_results]), axis=0
-                )
+            np.array([t.model_probabilities for t in results.trial_results]), axis=0
+        )
         fig, ax = plt.subplots(1, 1)
         for lv1 in range(N_MODELS):
             ax.plot(results.stamp, average_model_probabilities[lv1, :])
@@ -198,12 +266,15 @@ def test_reasonable_nees_imm(x0, P0, input_profile, process_model_true, measurem
 
         plt.show()
 
-    nees_in_correct_region =  np.count_nonzero(results.average_nees < 2*results.nees_upper_bound(0.99))
+    nees_in_correct_region = np.count_nonzero(
+        results.average_nees < 2 * results.nees_upper_bound(0.99)
+    )
     nt = results.average_nees.shape[0]
     # Proportion of time NEES remains below 2*upper_bound bigger than 90%
-    assert nees_in_correct_region/nt > 0.90
+    assert nees_in_correct_region / nt > 0.90
 
     # Make sure we essentially never get a completely absurd NEES.
-    nees_in_correct_region =  np.count_nonzero(results.average_nees < 50*results.nees_upper_bound(0.99))
-    assert nees_in_correct_region/nt > 0.9999
-
+    nees_in_correct_region = np.count_nonzero(
+        results.average_nees < 50 * results.nees_upper_bound(0.99)
+    )
+    assert nees_in_correct_region / nt > 0.9999

--- a/tests/integration/test_interacting_multiple_models.py
+++ b/tests/integration/test_interacting_multiple_models.py
@@ -23,8 +23,8 @@ from typing import List
 import time
 from matplotlib import pyplot as plt
 from pynav.imm import InteractingModelFilter, run_interacting_multiple_model_filter
-from pynav.imm import ImmResultList
-from pynav.imm import ImmState, gaussian_mixing, ImmResult
+from pynav.imm import IMMResultList
+from pynav.imm import IMMState, gaussian_mixing, IMMResult
 
 
 PLOT_FLAG = False
@@ -80,11 +80,11 @@ def make_filter_trial(dg, x0_true, P0, t_max, imm, process_model, Q_profile):
         )
 
         results = [
-            ImmResult(estimate_list[i], state_true[i])
+            IMMResult(estimate_list[i], state_true[i])
             for i in range(len(estimate_list))
         ]
 
-        return ImmResultList(results)
+        return IMMResultList(results)
 
     return imm_trial
 
@@ -180,11 +180,11 @@ def test_reasonable_nees_imm(
     t_max = dt * 100
     N = 10
     Q_dg = np.eye(x0.value.shape[0])
-    N_MODELS = len(imm_process_model_list)
+    n_models = len(imm_process_model_list)
     kf_list = [ExtendedKalmanFilter(pm) for pm in imm_process_model_list]
     off_diag_p = 0.02
-    Pi = np.ones((N_MODELS, N_MODELS)) * off_diag_p
-    Pi = Pi + (1 - off_diag_p * (N_MODELS)) * np.diag(np.ones(N_MODELS))
+    Pi = np.ones((n_models, n_models)) * off_diag_p
+    Pi = Pi + (1 - off_diag_p * (n_models)) * np.diag(np.ones(n_models))
     c_profile = make_c_profile(t_max)
     Q_profile = lambda t: c_profile(t) * Q_ref
 
@@ -259,7 +259,7 @@ def test_reasonable_nees_imm(
             np.array([t.model_probabilities for t in results.trial_results]), axis=0
         )
         fig, ax = plt.subplots(1, 1)
-        for lv1 in range(N_MODELS):
+        for lv1 in range(n_models):
             ax.plot(results.stamp, average_model_probabilities[lv1, :])
         ax.set_xlabel("Time (s)")
         ax.set_ylabel("Model Probabilities")

--- a/tests/integration/test_interacting_multiple_models.py
+++ b/tests/integration/test_interacting_multiple_models.py
@@ -1,0 +1,209 @@
+import pytest
+from pynav.filters import ExtendedKalmanFilter
+from pynav.lib.states import VectorState, SO3State, SE3State
+from pynav.datagen import DataGenerator
+from pynav.types import StampedValue, StateWithCovariance
+from pynav.utils import GaussianResult, GaussianResultList, MonteCarloResult
+from pynav.utils import randvec
+
+from pynav.utils import monte_carlo, plot_error
+from pynav.lib.models import DoubleIntegrator, OneDimensionalPositionVelocityRange
+from pynav.lib.models import SingleIntegrator, RangePointToAnchor
+from pynav.lib.models import (
+    BodyFrameVelocity,
+    InvariantMeasurement,
+    Magnetometer,
+    Gravitometer,
+)
+from pynav.lib.models import RangePoseToAnchor
+from pylie import SO3, SE3
+
+import numpy as np
+from typing import List
+import time
+from matplotlib import pyplot as plt
+from pynav.imm import InteractingModelFilter, run_interacting_multiple_model_filter
+from pynav.imm import ImmResultList
+
+PLOT_FLAG = False
+
+
+def make_onedimensional_range(R):
+    range_models=[
+        OneDimensionalPositionVelocityRange(R)
+    ]
+    return range_models
+
+def make_range_models_ekf_vector(R):
+    range_models = [
+        RangePointToAnchor([0, 4], R),
+        RangePointToAnchor([-2, 0], R),
+        RangePointToAnchor([2, 0], R),
+    ]
+    return range_models
+
+def make_invariant_so3_models(R):
+    mag_model = Magnetometer(R)
+    grav_model = Gravitometer(R)
+    return [mag_model, grav_model]
+
+def make_range_models_iterated_ekf(R):
+    range_models = [
+        RangePoseToAnchor([1, 0, 0], [0.17, 0.17, 0], R),
+        RangePoseToAnchor([1, 0, 0], [-0.17, 0.17, 0], R),
+        RangePoseToAnchor([-1, 0, 0], [0.17, 0.17, 0], R),
+        RangePoseToAnchor([-1, 0, 0], [-0.17, 0.17, 0], R),
+        RangePoseToAnchor([0, 2, 0], [0.17, 0.17, 0], R),
+        RangePoseToAnchor([0, 2, 0], [-0.17, 0.17, 0], R),
+        RangePoseToAnchor([0, 2, 2], [0.17, 0.17, 0], R),
+        RangePoseToAnchor([0, 2, 2], [-0.17, 0.17, 0], R),
+    ]
+    return range_models
+
+def make_filter_trial(dg, x0_true, P0, t_max, imm, process_model, Q_profile):
+        
+    def imm_trial(trial_number: int) -> List[GaussianResult]:
+        """
+        A single trial in a monte carlo experiment. This function accepts the trial
+        number and must return a list of GaussianResult objects.
+        """
+
+        # By using the trial number as the seed for the random generator, we can
+        # make sure our experiments are perfectly repeatable, yet still have
+        # independent noise samples from trial-to-trial.
+        np.random.seed(trial_number)
+        state_true, input_list, meas_list = dg.generate(x0_true, 0, t_max, True)
+
+        x0_check = x0_true.copy()
+        x0_check = x0_check.plus(randvec(P0))
+        estimate_list, model_probabilities = run_interacting_multiple_model_filter(imm, x0_check, P0, input_list, meas_list)
+
+        results = \
+        [
+            GaussianResult(estimate_list[i], state_true[i])
+            for i in range(len(estimate_list))
+        ]
+        
+        return ImmResultList(results, model_probabilities)
+    
+    return imm_trial
+
+# TODO: Generalize. Need to plot model probabilities vs true model. 
+# Need to take a step up from noise matrices to the models. 
+
+def make_c_profile_varying(t_max):
+    def c_profile(t):
+        if t <= t_max/4:
+            c = 1
+        if t > t_max/4 and t <= t_max*3/4:
+            c = 9
+        if t > t_max*3/4:
+            c = 1
+        return c
+    return c_profile
+
+def make_c_profile_const(t_max):
+    def c_profile(t):
+        return 1.
+    return c_profile
+
+
+@pytest.mark.parametrize("x0, P0, input_profile, process_model_true, measurement_model, \
+                        make_c_profile, R, input_freq, measurement_freq, imm_process_model_list, Q_ref", 
+            [
+                    (VectorState(np.array([1, 0]), 0.0), np.diag([1, 1]), 
+                    lambda t, x: np.array([np.sin(t), np.cos(t)]),
+                    SingleIntegrator, make_range_models_ekf_vector, 
+                    make_c_profile_varying, 0.1**2, 
+                    10, [1, 1, 1], [SingleIntegrator(1*np.eye(2)), SingleIntegrator(9*np.eye(2))], 
+                    np.eye(2)), 
+                    (VectorState(np.array([1, 0]), 0.0), np.diag([1, 1]), 
+                    lambda t, x: np.array([np.sin(t)]),
+                    DoubleIntegrator, make_onedimensional_range, 
+                    make_c_profile_varying, 0.1**4, 
+                    10, 5, [DoubleIntegrator(np.eye(1)), DoubleIntegrator(9*np.eye(1))], 
+                    np.eye(1)),
+                    (SE3State(SE3.Exp([0, 0, 0, 0, 0, 0]), stamp=0.0), 0.1**2 * np.identity(6), 
+                        lambda t, x: np.array([np.sin(0.1 * t), np.cos(0.1 * t), np.sin(0.1 * t), 1, 0, 0]),
+                        BodyFrameVelocity, make_range_models_iterated_ekf, 
+                        make_c_profile_varying, 0.1**2, 
+                        10, 5, 
+                        [BodyFrameVelocity(np.diag([0.01**2, 0.01**2, 0.01**2, 0.1, 0.1, 0.1])), 
+                        BodyFrameVelocity(9*np.diag([0.01**2, 0.01**2, 0.01**2, 0.1, 0.1, 0.1]))],
+                        np.diag([0.01**2, 0.01**2, 0.01**2, 0.1, 0.1, 0.1])
+                        ), 
+                 ])
+
+def test_reasonable_nees_imm(x0, P0, input_profile, process_model_true, measurement_model, 
+                make_c_profile, R, input_freq, measurement_freq, imm_process_model_list, Q_ref):
+    dt = 1/input_freq
+    t_max = dt*100
+    N = 10
+    Q_dg = np.eye(x0.value.shape[0])
+    N_MODELS = len(imm_process_model_list)
+    kf_list = [ExtendedKalmanFilter(pm) for pm in imm_process_model_list] 
+    off_diag_p = 0.02
+    Pi = np.ones((N_MODELS,N_MODELS))*off_diag_p
+    Pi = Pi+(1-off_diag_p*(N_MODELS))*np.diag(np.ones(N_MODELS))
+    c_profile = make_c_profile(t_max)
+    Q_profile = lambda t: c_profile(t)*Q_ref
+    dg = DataGenerator(
+        process_model_true(Q_dg),
+        input_profile,
+        Q_profile,
+        input_freq,
+        measurement_model(R),
+        measurement_freq,
+        )
+
+    imm_trial = make_filter_trial(dg, x0, P0, t_max, InteractingModelFilter(kf_list, Pi), process_model_true, Q_profile)
+    results = monte_carlo(imm_trial, N)
+
+    if PLOT_FLAG:
+        import matplotlib.pyplot as plt
+        import seaborn as sns
+
+        sns.set_theme()
+
+        fig, ax = plt.subplots(1, 1)
+        ax.plot(results.stamp, results.average_nees)
+        ax.plot(results.stamp, results.expected_nees, color="r", label="Expected NEES")
+        ax.plot( results.stamp, results.nees_lower_bound(0.99), color="k", linestyle="--", label="99 percent c.i.",)
+        ax.plot(results.stamp, results.nees_upper_bound(0.99), color="k", linestyle="--",)
+        ax.set_title("{0}-trial average NEES".format(results.num_trials))
+        ax.set_ylim(0, None)
+        ax.set_xlabel("Time (s)")
+        ax.set_ylabel("NEES")
+        ax.legend()
+
+
+        if N < 15:
+
+            fig, axs = plt.subplots(2, 1)
+            axs: List[plt.Axes] = axs
+            for result in results.trial_results:
+                plot_error(result, axs=axs)
+
+            axs[0].set_title("Estimation error")
+            axs[1].set_xlabel("Time (s)")
+
+        average_model_probabilities = np.average(
+                    np.array([t.model_probabilities for t in results.trial_results]), axis=0
+                )
+        fig, ax = plt.subplots(1, 1)
+        for lv1 in range(N_MODELS):
+            ax.plot(results.stamp, average_model_probabilities[lv1, :])
+        ax.set_xlabel("Time (s)")
+        ax.set_ylabel("Model Probabilities")
+
+        plt.show()
+
+    nees_in_correct_region =  np.count_nonzero(results.average_nees < 2*results.nees_upper_bound(0.99))
+    nt = results.average_nees.shape[0]
+    # Proportion of time NEES remains below 2*upper_bound bigger than 90%
+    assert nees_in_correct_region/nt > 0.90
+
+    # Make sure we essentially never get a completely absurd NEES.
+    nees_in_correct_region =  np.count_nonzero(results.average_nees < 50*results.nees_upper_bound(0.99))
+    assert nees_in_correct_region/nt > 0.9999
+

--- a/tests/integration/test_invariant_so3.py
+++ b/tests/integration/test_invariant_so3.py
@@ -14,7 +14,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 from sympy import re
 
-    
 
 
 def generate_so3_results():


### PR DESCRIPTION
Added interacting multiple model filter. As examples, right now have process model noise estimation. 
Issues with this PR right now:
- Duplication of the ExtendedKalmanFilter into ExtendedKalmanFilterIMM. This is because the IMM needs innovation and innovation covariance which the vanulla EKF class does not return. So theres a good chunk of code duplication (the entire correct method). If anyone has an idea of how to do this better, would appreciate. 
- For now, only implemented for right perturbation. 



